### PR TITLE
Don't scramble the already-scrambled 1st_read.bin

### DIFF
--- a/make-cd/Makefile
+++ b/make-cd/Makefile
@@ -1,5 +1,4 @@
 CDRECORD	= wodim dev=0,0,0 speed=8
-SCRAMBLE	= scramble
 DD		= dd
 CP		= cp
 MKISOFS		= genisoimage
@@ -20,7 +19,7 @@ burn-audio: audio.raw
 	touch burn-audio
 
 1st_read.bin: $(1ST_READ)
-	$(SCRAMBLE) $(1ST_READ) 1st_read.bin
+	cp $(1ST_READ) 1st_read.bin
 
 data.raw: tmp.iso IP.BIN
 	( cat IP.BIN ; dd if=tmp.iso bs=2048 skip=16 ) > data.raw


### PR DESCRIPTION
target-src/1st_read/Makefile runs scramble on 1st_read.bin, so it does not need to be scrambled again here.