### PR TITLE
Always remove leading-zeros from IP address

### DIFF
--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -477,18 +477,14 @@ int open_socket(char *hostname)
     sin.sin_family = AF_INET;
     sin.sin_port = htons(31313);
 
+    // Try to remove leading zeros from hostname...
+    cleanup_ip_address(hostname);
     host = gethostbyname(hostname);
 
-	if (!host) {
-		// Try to remove leading zeros from hostname...
-		cleanup_ip_address(hostname);
-		host = gethostbyname(hostname);
-		if (!host) {
-			// definitely, we can't do nothing
-			log_error("gethostbyname");
-			return -1;
-		}
-	}
+    if (!host) {
+	log_error("gethostbyname");
+	return -1;
+    }
 
     memcpy((char *)&sin.sin_addr, host->h_addr, host->h_length);
 


### PR DESCRIPTION
On many platforms, leading-zeros in an octet cause the octet to be interpreted as octal, so they should always be removed before trying to connect.