### PR TITLE
dc-tool-ip: make hostname point to a heap-allocated string by default

### DIFF
--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -1317,7 +1317,7 @@ int main(int argc, char *argv[])
     char *filename = 0;
     char *isofile = 0;
     char *path = 0;
-    char *hostname = DREAMCAST_IP;
+    char *hostname = strdup(DREAMCAST_IP);
     char *cleanlist[4] = { 0, 0, 0, 0 };
 
     if (argc < 2) {


### PR DESCRIPTION
previously it was pointing to a const char* by default; this was
causing segfaults on my PC because cleanup_ip_address would try to
write to it.  With this commit, that is no longer a problem

using the -t option is a viable workaround to this bug since it
points hostname to a heap-allocated string; however without this it
defaults to DREAMCAST_IP, which is a const char*.