### PR TITLE
DHCP compatibility fixes

### DIFF
--- a/target-src/dcload/dhcp.c
+++ b/target-src/dcload/dhcp.c
@@ -49,6 +49,10 @@
 // stack space to get remotely close to that.
 #define DHCP_NAK_NEST_MAX 5
 
+// Minimum size in bytes for the DHCP options area
+#define DHCP_MIN_OPTIONS_SIZE 64
+
+
 static unsigned int get_some_time(int which);
 static void build_send_dhcp_packet(unsigned char kind);
 static int kos_net_dhcp_fill_options(unsigned char *bbmac, dhcp_pkt_t *req, uint8 msgtype);
@@ -481,7 +485,7 @@ static int kos_net_dhcp_fill_options(unsigned char *bbmac, dhcp_pkt_t *req, uint
     /* The End */
     req->options[pos++] = DHCP_OPTION_END;
 
-    return pos;
+    return (pos < DHCP_MIN_OPTIONS_SIZE) ? DHCP_MIN_OPTIONS_SIZE : pos;
 }
 
 // Modified very slightly from KOS

--- a/target-src/dcload/dhcp.c
+++ b/target-src/dcload/dhcp.c
@@ -49,6 +49,9 @@
 // stack space to get remotely close to that.
 #define DHCP_NAK_NEST_MAX 5
 
+// Minimum size in bytes for the DHCP options area
+#define DHCP_MIN_OPTIONS_SIZE 64
+
 static unsigned int get_some_time(int which);
 static void build_send_dhcp_packet(unsigned char kind);
 static int kos_net_dhcp_fill_options(unsigned char *bbmac, dhcp_pkt_t *req, uint8 msgtype);
@@ -481,7 +484,7 @@ static int kos_net_dhcp_fill_options(unsigned char *bbmac, dhcp_pkt_t *req, uint
     /* The End */
     req->options[pos++] = DHCP_OPTION_END;
 
-    return pos;
+    return (pos < DHCP_MIN_OPTIONS_SIZE) ? DHCP_MIN_OPTIONS_SIZE : pos;
 }
 
 // Modified very slightly from KOS

--- a/target-src/dcload/dhcp.c
+++ b/target-src/dcload/dhcp.c
@@ -49,10 +49,6 @@
 // stack space to get remotely close to that.
 #define DHCP_NAK_NEST_MAX 5
 
-// Minimum size in bytes for the DHCP options area
-#define DHCP_MIN_OPTIONS_SIZE 64
-
-
 static unsigned int get_some_time(int which);
 static void build_send_dhcp_packet(unsigned char kind);
 static int kos_net_dhcp_fill_options(unsigned char *bbmac, dhcp_pkt_t *req, uint8 msgtype);
@@ -485,7 +481,7 @@ static int kos_net_dhcp_fill_options(unsigned char *bbmac, dhcp_pkt_t *req, uint
     /* The End */
     req->options[pos++] = DHCP_OPTION_END;
 
-    return (pos < DHCP_MIN_OPTIONS_SIZE) ? DHCP_MIN_OPTIONS_SIZE : pos;
+    return pos;
 }
 
 // Modified very slightly from KOS

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -835,6 +835,15 @@ void rtl_bb_loop(int is_main_loop)
 			if (booted && (!running))
 			{
 				disp_status("idle...");
+
+				/* sleep for 241ms to ensure link is really up; without this, some networks fail */
+
+				int i, cnt;
+				volatile unsigned int *a05f688c = (volatile unsigned int*)0xa05f688c;
+
+				cnt = 0x1800 * 0x58e * 241 / 1000;
+				for (i=0; i<cnt; i++)
+					(void)*a05f688c;
 			}
 
 			rtl_link_up = 1; // Good to go!

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -835,15 +835,6 @@ void rtl_bb_loop(int is_main_loop)
 			if (booted && (!running))
 			{
 				disp_status("idle...");
-
-				/* sleep for 241ms to ensure link is really up; without this, some networks fail */
-
-				int i, cnt;
-				volatile unsigned int *a05f688c = (volatile unsigned int*)0xa05f688c;
-
-				cnt = 0x1800 * 0x58e * 241 / 1000;
-				for (i=0; i<cnt; i++)
-					(void)*a05f688c;
 			}
 
 			rtl_link_up = 1; // Good to go!


### PR DESCRIPTION
- In rtl8139.c, added 241ms of sleep after BBA link is up and before DHCP process starts, which fixes DHCP problems on several users' networks including my own
- In dhcp.c, DHCP options area is now set to minimum 64 bytes size for compatibility (thanks BigEvilCorp and kazade for this fix)