### PR TITLE
Adjust sleep period to only apply to DHCP mode, adjust from 241ms to 490ms for greater network compatibility

### DIFF
--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -835,15 +835,6 @@ void rtl_bb_loop(int is_main_loop)
 			if (booted && (!running))
 			{
 				disp_status("idle...");
-
-				/* sleep for 241ms to ensure link is really up; without this, some networks fail */
-
-				int i, cnt;
-				volatile unsigned int *a05f688c = (volatile unsigned int*)0xa05f688c;
-
-				cnt = 0x1800 * 0x58e * 241 / 1000;
-				for (i=0; i<cnt; i++)
-					(void)*a05f688c;
 			}
 
 			rtl_link_up = 1; // Good to go!


### PR DESCRIPTION
Previously, I added a 241ms delay after bringing the network link up because some networks were still not ready for the DHCPDISCOVER packet when dcload-ip sent it. In this situation, dcload-ip gets stuck in a loop waiting for a DHCP OFFER packet that will never arrive. Although 241ms worked for most users, some users have still reported issues. Therefore, this PR adjusts the delay to 490ms. In addition, the delay has been moved from where the link is brought up and instead applied to before the DHCPDISCOVER packet is sent. This way, it only applies to DHCP users and doesn't unnecessarily delay for static IP and ARP users. 

This is a quick fix and ultimately the DHCP implementation should be rewritten so that the loop times out and the DHCPDISCOVER packet is sent again at a different time interval. 