### PR TITLE
Retry DHCP handshake if response is not received

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,13 @@
+WHAT'S NEW IN 2.0.1
+
+* dcload-ip now retries DHCP handshake if it doesn't get any response. This fixes
+  a bug present on many networks where dcload-ip sends out a DHCP DISCOVER packet
+  before the link is ready, then gets stuck in a loop waiting for a response that
+  will never come. The DHCP handshake will be retried at regular increasing
+  intervals up to 30 secs between retries. While retrying the handshake, a counter
+  will appear showing the retries. Upon receiving a DHCP acknowledgement, the
+  counter text will be cleared to then show the DHCP lease time.
+
 WHAT'S NEW IN 2.0.0
 
 * The number of packets dc-tool sends per burst, as well as the delay between

--- a/Makefile.cfg
+++ b/Makefile.cfg
@@ -99,7 +99,7 @@ endif
 # You generally shouldn't change this unless you are making forked
 # versions (or test versions)
 # Version numbers must be of the form x.x.x
-VERSION = 2.0.0
+VERSION = 2.0.1
 
 # Define this if you want a standalone, statically linked, no dependency binary
 #STANDALONE_BINARY = 1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# dcload-ip 2.0.0
+# dcload-ip 2.0.1
 
 A Dreamcast ethernet loader originally by [Andrew Kieschnick](http://napalm-x.thegypsy.com/andrewk/dc/).
 Updated and overhauled by Moopthehedgehog
@@ -45,7 +45,7 @@ options meant for a portable copy of GCC 9.2/Binutils 2.33.1 compiled with an
 
 * The correct display is something like:
 
-  `dcload-ip 2.0.0`  <- name/version  
+  `dcload-ip 2.0.1`  <- name/version
   `Broadband Adapter (HIT-0400)`  <- adapter driver in use  
   `00:d0:f1:02:ab:dd`  <- dc hardware address  
   `192.168.1.92`  <- dc ip address  
@@ -284,7 +284,9 @@ section for that
 
 * [SiZiOUS](https://www.github.com/SiZiOUS) for maintaining this program
 * rtl8139 code based on code by Dan Potter
-* LAN Adapter driver code is derived from an early version of the KOS LA driver
+* LAN Adapter driver code, originally derived from early KOS, majorly overhauled by Moopthehedgehog
+* DHCP support, exception dumping, perf counters, performance improvements by Moopthehedgehog
+* DHCP retry functionality by darcagn
 * There are some various files from `newlib-1.8.2` here
 * `video.s`, `maple.c`, and `maple.h` were written by Marcus Comstedt
 * initial win32 porting and implementation of -t by Florian 'Proff' Schulze

--- a/target-src/dcload/adapter.c
+++ b/target-src/dcload/adapter.c
@@ -4,6 +4,8 @@
 
 // Loop escape flag, used by all drivers.
 volatile unsigned char escape_loop = 0;
+int timeout_loop = 0;
+int loop_secs_elapsed = 0;
 
 // The currently configured driver.
 adapter_t * bb;

--- a/target-src/dcload/adapter.h
+++ b/target-src/dcload/adapter.h
@@ -58,6 +58,10 @@ extern adapter_t adapter_bba;
 
 // Set this variable to non-zero if you want the loop to exit.
 extern volatile unsigned char escape_loop;
+// If you want the loop to have a timeout, set this int to # of secs.
+// Else, leave it as zero. If loop times out, it will be set to -1 and need resetting.
+extern int timeout_loop;
+extern int loop_secs_elapsed;
 
 // All adapter drivers should use this shared buffer to receive.
 extern __attribute__((aligned(32))) unsigned char raw_current_pkt[RAW_RX_PKT_BUF_SIZE];

--- a/target-src/dcload/dcload.c
+++ b/target-src/dcload/dcload.c
@@ -366,7 +366,7 @@ static void update_lease_time_display(unsigned int new_time)
 {
 	// Casting to char gets rid of GCC warning.
 	uint_to_string_dec(new_time, dhcp_lease_time_string);
-	clear_lines(424, 48, global_bg_color);
+	clear_lines(424, 48, global_bg_color); // Clear 48 lines so DHCP retry attempts text is also cleared
 	draw_string(30, 448, dhcp_lease_string, STR_COLOR);
 	draw_string(306, 448, dhcp_lease_time_string, STR_COLOR);
 }

--- a/target-src/dcload/dcload.c
+++ b/target-src/dcload/dcload.c
@@ -87,7 +87,11 @@ static const char *waiting_string = "Waiting for IP..."; // Waiting for IP indic
 static const char *dhcp_mode_string = " (DHCP Mode)"; // Indicator that DHCP is active
 static const char *dhcp_timeout_string = " (DHCP Timed Out!)"; // DHCP timeout indicator
 static const char *dhcp_lease_string = "DHCP Lease Time (sec): "; // DHCP lease time
+static const char *dhcp_attempts_string = "DHCP Attempts: "; // DHCP attempts amount
+static const char *dhcp_next_string = "Next attempt in... "; // DHCP attempt countdown
 static char dhcp_lease_time_string[11] = {0}; // For converting lease time to seconds. 10 characters + null term. Max lease is theoretically 4294967295, but really is 1410902 due to perf counters.
+static char dhcp_attempts_num[9] = {0};
+static char dhcp_next_counter[9] = {0};
 
 /* converts expevt value to description, used by exception handler */
 char * exception_code_to_string(unsigned int expevt)
@@ -278,6 +282,22 @@ void disp_status(const char * status) {
 	draw_string(30, 150, status, STR_COLOR);
 }
 
+void disp_dhcp_attempts_count(void)
+{
+	clear_lines(424, 24, global_bg_color);
+	draw_string(30, 424, dhcp_attempts_string, STR_COLOR);
+	uint_to_string_dec(dhcp_attempts, dhcp_attempts_num);
+	draw_string(160, 424, dhcp_attempts_num, STR_COLOR);
+}
+
+void disp_dhcp_next_attempt(unsigned int time_left)
+{
+	clear_lines(448, 24, global_bg_color);
+	draw_string(30, 448, dhcp_next_string, STR_COLOR);
+	uint_to_string_dec(time_left, dhcp_next_counter);
+	draw_string(160, 448, dhcp_next_counter, STR_COLOR);
+}
+
 // The C language technically requires that all uninitialized global variables
 // get initted to 0 via .bss, which is something I really don't like relying on.
 // 'our_ip' is declared in commands.c, of all places, and is not given an
@@ -346,7 +366,7 @@ static void update_lease_time_display(unsigned int new_time)
 {
 	// Casting to char gets rid of GCC warning.
 	uint_to_string_dec(new_time, dhcp_lease_time_string);
-	clear_lines(448, 24, global_bg_color);
+	clear_lines(424, 48, global_bg_color);
 	draw_string(30, 448, dhcp_lease_string, STR_COLOR);
 	draw_string(306, 448, dhcp_lease_time_string, STR_COLOR);
 }

--- a/target-src/dcload/dcload.h
+++ b/target-src/dcload/dcload.h
@@ -103,6 +103,8 @@ void setup_video(unsigned int mode, unsigned int color);
 // Called by other parts of dcload
 void disp_info(void);
 void disp_status(const char * status);
+void disp_dhcp_attempts_count(void);
+void disp_dhcp_next_attempt(unsigned int);
 void clear_lines(unsigned int y, unsigned int n, unsigned int c);
 void uint_to_string_dec(unsigned int foo, char *bar);
 

--- a/target-src/dcload/dhcp.c
+++ b/target-src/dcload/dhcp.c
@@ -263,9 +263,11 @@ int dhcp_go(unsigned int *dhcp_ip_address_buffer) // Address buffer comes in as 
 	dhcp_attempts = 0;
 	timeout_loop = 1;   // Initial timeout in secs for waiting for DHCP response
 
-	while(!dhcp_acked) { // Loop DHCP attempts until acked
-		dhcp_attempts++;		// Increase the attempt count
-		if (timeout_loop < 0) { // If timeout_loop is -1, we arrived here from a timeout waiting for a DHCP response
+	while(!dhcp_acked)  // Loop DHCP attempts until acked
+	{
+		dhcp_attempts++; // Increase the attempt count
+		if (timeout_loop < 0) // If timeout_loop is -1, we arrived here from a timeout waiting for a DHCP response
+		{
 			timeout_loop = (dhcp_attempts > 10 ? 30 : 3*(dhcp_attempts)); // Increase the timeout for the next attempt, max 30 secs
 		}
 		build_send_dhcp_packet(DHCP_MSG_DHCPDISCOVER);
@@ -276,7 +278,8 @@ int dhcp_go(unsigned int *dhcp_ip_address_buffer) // Address buffer comes in as 
 		if (timeout_loop < 0) continue; // If timed out waiting for DHCP ACK, this will be -1, start over
 	}
 
-	timeout_loop = 0;
+	dhcp_attempts = 0; // Done with these variables now
+	timeout_loop = 0;  // Reset them for potential future use
 
 	if(dhcp_acked && dhcp_nest_counter)
 	{

--- a/target-src/dcload/dhcp.c
+++ b/target-src/dcload/dhcp.c
@@ -70,6 +70,7 @@ static unsigned char dhcp_renewal = 0;
 static unsigned char dhcp_renewal_nak = 0;
 static unsigned char dhcp_nest_counter = 0;
 unsigned char dhcp_nest_counter_maxed = 0;
+unsigned int dhcp_attempts = 0;
 
 static unsigned char router_mac[6] = {0}; // BE
 
@@ -259,11 +260,23 @@ int dhcp_go(unsigned int *dhcp_ip_address_buffer) // Address buffer comes in as 
 {
 	dhcp_acked = 0;
 	dhcp_nest_counter++;
+	dhcp_attempts = 0;
+	timeout_loop = 1;   // Initial timeout in secs for waiting for DHCP response
 
- 	build_send_dhcp_packet(DHCP_MSG_DHCPDISCOVER);
-	bb->loop(0); // Wait for DHCP OFFER packet
- 	build_send_dhcp_packet(DHCP_MSG_DHCPREQUEST);
-	bb->loop(0); // Wait for DHCP ACK (or NAK...)
+	while(!dhcp_acked) { // Loop DHCP attempts until acked
+		dhcp_attempts++;		// Increase the attempt count
+		if (timeout_loop < 0) { // If timeout_loop is -1, we arrived here from a timeout waiting for a DHCP response
+			timeout_loop = (dhcp_attempts > 10 ? 30 : 3*(dhcp_attempts)); // Increase the timeout for the next attempt, max 30 secs
+		}
+		build_send_dhcp_packet(DHCP_MSG_DHCPDISCOVER);
+		bb->loop(0); // Wait for DHCP OFFER packet
+		if (timeout_loop < 0) continue; // If timed out waiting for DHCP OFFER, this will be -1, start over
+ 		build_send_dhcp_packet(DHCP_MSG_DHCPREQUEST);
+		bb->loop(0); // Wait for DHCP ACK (or NAK...)
+		if (timeout_loop < 0) continue; // If timed out waiting for DHCP ACK, this will be -1, start over
+	}
+
+	timeout_loop = 0;
 
 	if(dhcp_acked && dhcp_nest_counter)
 	{

--- a/target-src/dcload/dhcp.h
+++ b/target-src/dcload/dhcp.h
@@ -190,6 +190,7 @@ typedef struct __attribute__((packed, aligned(4))) {
 
 extern volatile unsigned int dhcp_lease_time;
 extern unsigned char dhcp_nest_counter_maxed;
+extern unsigned int dhcp_attempts;
 
 int handle_dhcp_reply(unsigned char *routersrcmac, dhcp_pkt_t *pkt_data, unsigned short len);
 int dhcp_go(unsigned int *dhcp_ip_address_buffer);

--- a/target-src/dcload/lan_adapter.c
+++ b/target-src/dcload/lan_adapter.c
@@ -34,6 +34,7 @@
 //#define LAN_FULL_TRIP_TIMING
 
 #ifdef LAN_LOOP_TIMING
+//#include "perfctr.h"
 static char uint_string_array[11] = {0};
 #endif
 // end TEMP
@@ -622,7 +623,8 @@ void la_bb_loop(int is_main_loop)
 		lan_link_up = 0;
 	}
 
-	if (timeout_loop > 0) {
+	if (timeout_loop > 0)
+	{
 		PMCR_Read(DCLOAD_PMCR, loop_start);
 	}
 
@@ -690,6 +692,7 @@ void la_bb_loop(int is_main_loop)
 			 * immediately upon bringing link back up, so we can retry immediately */
 			if (timeout_loop > 0 )
 			{
+				dhcp_attempts = 0;
 				timeout_loop = -1;
 				escape_loop = 1;
 			}

--- a/target-src/dcload/lan_adapter.c
+++ b/target-src/dcload/lan_adapter.c
@@ -14,6 +14,7 @@
 
 #include "dhcp.h"
 #include "memfuncs.h"
+#include "perfctr.h"
 
 // Here's a datasheet for the FUJITSU MB86967 chip:
 // https://pdf1.alldatasheet.com/datasheet-pdf/view/61702/FUJITSU/MB86967.html
@@ -33,7 +34,6 @@
 //#define LAN_FULL_TRIP_TIMING
 
 #ifdef LAN_LOOP_TIMING
-#include "perfctr.h"
 static char uint_string_array[11] = {0};
 #endif
 // end TEMP
@@ -599,6 +599,9 @@ void la_bb_loop(int is_main_loop)
 {
 	int result;
 	int link_change_message = 0;
+	unsigned int loop_start[2] = {0};
+	unsigned int loop_measure[2] = {0};
+	unsigned int prev_loop_elapsed = 0;
 
 	DEBUG("bb_loop entered\r\n");
 
@@ -617,6 +620,10 @@ void la_bb_loop(int is_main_loop)
 		// In the event a user actually connects to something NOT using autonegotiation,
 		// set lan_link_up to 0 so that this loop can work with those, too.
 		lan_link_up = 0;
+	}
+
+	if (timeout_loop > 0) {
+		PMCR_Read(DCLOAD_PMCR, loop_start);
 	}
 
 	while (!escape_loop)
@@ -679,6 +686,14 @@ void la_bb_loop(int is_main_loop)
 				link_change_message = 0;
 			}
 
+			/* if we were waiting in a loop with a timeout when link changed, timeout
+			 * immediately upon bringing link back up, so we can retry immediately */
+			if (timeout_loop > 0 )
+			{
+				timeout_loop = -1;
+				escape_loop = 1;
+			}
+
 			// Good to go!
 			lan_link_up = 1;
 		}
@@ -696,6 +711,26 @@ void la_bb_loop(int is_main_loop)
 			// Do we need to renew our IP address?
 			// This will override set_ip_from_file() if the ip is in the 0.0.0.0/8 range
 			set_ip_dhcp();
+		}
+
+		if(timeout_loop > 0)
+		{
+			PMCR_Read(DCLOAD_PMCR, loop_measure);
+			unsigned int loop_secs_elapsed = (unsigned int)((*(unsigned long long int*)loop_measure - *(unsigned long long int*)loop_start)/200000000);
+			if(prev_loop_elapsed != loop_secs_elapsed)
+			{
+				if(dhcp_attempts > 1) // Don't show a counter yet if it's the first attempt
+				{
+					disp_dhcp_attempts_count();
+					disp_dhcp_next_attempt(timeout_loop - loop_secs_elapsed + 1);
+				}
+				if(loop_secs_elapsed > (unsigned int) timeout_loop)
+				{
+					timeout_loop = -1;
+					escape_loop = 1;
+				}
+				prev_loop_elapsed = loop_secs_elapsed;
+			}
 		}
 	}
 

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -22,6 +22,7 @@
 //#define FULL_TRIP_TIMING
 
 #ifdef LOOP_TIMING
+//#include "perfctr.h"
 #include "video.h"
 static char uint_string_array[11] = {0};
 #endif
@@ -796,7 +797,8 @@ void rtl_bb_loop(int is_main_loop)
 		rtl_link_up = 0;
 	}
 
-	if (timeout_loop > 0) {
+	if (timeout_loop > 0)
+	{
 		PMCR_Read(DCLOAD_PMCR, loop_start);
 	}
 
@@ -839,21 +841,13 @@ void rtl_bb_loop(int is_main_loop)
 			if (booted && (!running))
 			{
 				disp_status("idle...");
-
-				/* sleep for 241ms to ensure link is really up; without this, some networks fail */
-
-				int i, cnt;
-				volatile unsigned int *a05f688c = (volatile unsigned int*)0xa05f688c;
-
-				cnt = 0x1800 * 0x58e * 241 / 1000;
-				for (i=0; i<cnt; i++)
-					(void)*a05f688c;
 			}
 
 			/* if we were waiting in a loop with a timeout when link changed, timeout
 			 * immediately upon bringing link back up, so we can retry immediately */
 			if (timeout_loop > 0 )
 			{
+				dhcp_attempts = 0;
 				timeout_loop = -1;
 				escape_loop = 1;
 			}
@@ -921,7 +915,6 @@ void rtl_bb_loop(int is_main_loop)
 				prev_loop_elapsed = loop_secs_elapsed;
 			}
 		}
-
 	}
 	escape_loop = 0;
 }


### PR DESCRIPTION
Fixes issue #14

```
WHAT'S NEW IN 2.0.1

* dcload-ip now retries DHCP handshake if it doesn't get any response. This fixes
  a bug present on many networks where dcload-ip sends out a DHCP DISCOVER packet
  before the link is ready, then gets stuck in a loop waiting for a response that
  will never come. The DHCP handshake will be retried at regular increasing
  intervals up to 30 secs between retries. While retrying the handshake, a counter
  will appear showing the retries. Upon receiving a DHCP acknowledgement, the
  counter text will be cleared to then show the DHCP lease time.
```

Here's a video demonstrating the new functionality. dcload-ip is started on a Dreamcast connected to a network with no DHCP server available. After try number 6, a DHCP server is connected and the retry successfully gets a lease. 

https://github.com/sizious/dcload-ip/assets/5105103/423dbe65-54c8-4823-ab64-3821827b4946