### PR TITLE
Fixed crash on GDB disconnect.

### DIFF
--- a/host-src/tool/syscalls.c
+++ b/host-src/tool/syscalls.c
@@ -31,6 +31,7 @@
 #include <utime.h>
 #include <dirent.h>
 #include <string.h>
+#include <errno.h>
 #ifdef __MINGW32__
 #include <windows.h>
 #else
@@ -545,6 +546,11 @@ int dc_gdbpacket(unsigned char * buffer)
 	fprintf(stderr, "Got socket error: %d\n", WSAGetLastError());
 	return -1;
 	}
+#else
+    if(retval == -1) {
+        fprintf(stderr, "Got socket error: %s\n", strerror(errno));
+        return -1;
+    }
 #endif
     send_cmd(CMD_RETVAL, retval, retval, (unsigned char *)gdb_buf, retval);
 


### PR DESCRIPTION
- We were getting a -1 from recv(), which we were then passing on to send_command(), which was causing a buffer overflow and crash. It seems as though MinGW might be protected from this.

Here's a repro + coredump:
![Screenshot from 2023-09-07 20-11-08](https://github.com/sizious/dcload-ip/assets/5545520/390565cb-46d7-434f-b2d4-bf35092dd099)
