### PR TITLE
Set socket option to reuse address with GDB connections

### DIFF
--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -1278,6 +1278,17 @@ int open_gdb_socket(int port)
 	return -1;
   }
 
+  const int enable_reuse_addr = 1;
+  int checkopt = setsockopt(gdb_server_socket, SOL_SOCKET, SO_REUSEADDR, 
+                            &enable_reuse_addr, sizeof(enable_reuse_addr));
+#ifdef __MINGW322__
+  if( checkopt == SOCKET_ERROR ) {
+#else 
+  if( checkopt < 0 ) {
+#endif 
+    log_error( "warning: failed to set gdb socket options" );
+  }
+
   int checkbind = bind( gdb_server_socket, (struct sockaddr*)&server_addr, sizeof( server_addr ) );
 #ifdef __MINGW32__
 	if( checkbind == SOCKET_ERROR ) {


### PR DESCRIPTION
- Previously, if you had completed a debugging session and had started a new one too quickly, you could very frequently get the error "error binding gdb server socket" which would also freeze the DC, making it need a hard reboot
- This is because the OS hadn't had a chance to terminate the existing socket bound to the existing address
- This commit sets the socket to allow for reuse of local addresses

Please refer to the accepted answer here for a full detailed description of the socket option I set and a description of the issues we've had without it: https://stackoverflow.com/questions/3229860/what-is-the-meaning-of-so-reuseaddr-setsockopt-option-linux

NOTE: I have not actually had the chance to ensure this builds with MinGW32 still; however, I did Google and it looks correct. 