### PR TITLE
Fixed typo for #ifdef __MINGW32__

### DIFF
--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -1281,7 +1281,7 @@ int open_gdb_socket(int port)
   const int enable_reuse_addr = 1;
   int checkopt = setsockopt(gdb_server_socket, SOL_SOCKET, SO_REUSEADDR, 
                             &enable_reuse_addr, sizeof(enable_reuse_addr));
-#ifdef __MINGW322__
+#ifdef __MINGW32__
   if( checkopt == SOCKET_ERROR ) {
 #else 
   if( checkopt < 0 ) {


### PR DESCRIPTION
Sorry about this one. I was porting these chances over to dc-tool-ip, when I noticed a typo...

- Typo for #ifdef in open_gdb_socket() when checking for an error after the setsockopt() call while using MINGW32.