### PR TITLE
dcload: Use P1 area instead of P0

### DIFF
--- a/target-src/dcload/lan_adapter.c
+++ b/target-src/dcload/lan_adapter.c
@@ -409,7 +409,7 @@ int la_bb_tx(unsigned char *pkt, int len)
 	uint_to_string(len, buffer);
 	draw_string(0, 192, buffer, 0xffff); */
 
-	unsigned char *copyback_pkt = (unsigned char*)((unsigned int)pkt & 0x1fffffff);
+	unsigned char *copyback_pkt = to_p1(pkt);
 
 // Tx time
 #ifdef LAN_TX_LOOP_TIMING
@@ -543,7 +543,7 @@ static int la_bb_rx(void)
 			return -2;
 		}
 
-		unsigned char *copyback_current_pkt = (unsigned char*)((unsigned int)current_pkt & 0x1fffffff); // copyback pkt in cached memory area
+		unsigned char *copyback_current_pkt = to_p1(current_pkt); // copyback pkt in cached memory area
 
 // Rx time
 #ifdef LAN_RX_LOOP_TIMING
@@ -557,7 +557,7 @@ static int la_bb_rx(void)
 			copyback_current_pkt[i] = REG(8);
 		}
 		// Ensure cached data is written to memory
-		CacheBlockWriteBack((unsigned char*) ((unsigned int)raw_current_pkt & 0x1fffffe0), (2 + len + 31)/32);
+		CacheBlockWriteBack(to_p1(raw_current_pkt), (2 + len + 31)/32);
 
 // Rx time end
 #ifdef LAN_RX_LOOP_TIMING

--- a/target-src/dcload/maple.c
+++ b/target-src/dcload/maple.c
@@ -122,8 +122,8 @@ void *maple_docmd(int port, int unit, int cmd, int datalen, void *data)
 //    memcpy(sendbuf, data, datalen << 2); // sendbuf is 32-byte aligned, offset by 12. data is 8-byte aligned, offset by 4 due to port, unit, cmd, & datalen
     // So memcpy_32bit the first 4 bytes to make it all 8-byte aligned (remaining sendbuf will be 16-byte aligned and remaining data will be 8-byte aligned)
     memcpy_32bit(sendbuf, data, 4/4);
-    SH4_aligned_memcpy((void*) (((unsigned int)sendbuf + 4) & 0x1fffffff), (void*) (((unsigned int)data + 4) & 0x1fffffff), datalen - 1); // use copy-back memory area for speed boost
-    CacheBlockWriteBack((unsigned char*) ((unsigned int)sendbuf & 0x1fffffe0), ((datalen * 4) + 31)/32); // Synchronize memory with opcache in 32-byte blocks, sendbuf is already 32-byte aligned
+    SH4_aligned_memcpy(to_p1((void *)sendbuf + 4), to_p1((void *)data + 4), datalen - 1); // use copy-back memory area for speed boost
+    CacheBlockWriteBack(to_p1((void *)((unsigned int)sendbuf & ~0x1f)), ((datalen * 4) + 31)/32); // Synchronize memory with opcache in 32-byte blocks, sendbuf is already 32-byte aligned
     // Need to do that so DMA sees the data in memory
   }
 

--- a/target-src/dcload/memfuncs.c
+++ b/target-src/dcload/memfuncs.c
@@ -22,6 +22,11 @@
 // Len is (# of total bytes/1), so it's "# of 8-bits"
 // Source and destination buffers must both be 1-byte aligned (aka no alignment)
 
+static unsigned int memdiff(const void *dst, const void *src)
+{
+	return ((unsigned int)dst & 0x1fffffff) - ((unsigned int)src & 0x1fffffff);
+}
+
 void * memcpy_8bit(void *dest, const void *src, unsigned int len)
 {
   if(!len)
@@ -32,7 +37,7 @@ void * memcpy_8bit(void *dest, const void *src, unsigned int len)
   const char *s = (char *)src;
   char *d = (char *)dest;
 
-  unsigned int diff = (unsigned int)d - (unsigned int)(s + 1); // extra offset because input gets incremented before output is calculated
+  unsigned int diff = memdiff(d, s + 1); // extra offset because input gets incremented before output is calculated
   // Underflow would be like adding a negative offset
 
   // Can use 'd' as a scratch reg now
@@ -66,7 +71,7 @@ void * memcpy_16bit(void *dest, const void *src, unsigned int len)
   const unsigned short* s = (unsigned short*)src;
   unsigned short* d = (unsigned short*)dest;
 
-  unsigned int diff = (unsigned int)d - (unsigned int)(s + 1); // extra offset because input gets incremented before output is calculated
+  unsigned int diff = memdiff(d, s + 1); // extra offset because input gets incremented before output is calculated
   // Underflow would be like adding a negative offset
 
   // Can use 'd' as a scratch reg now
@@ -100,7 +105,7 @@ void * memcpy_32bit(void *dest, const void *src, unsigned int len)
   const unsigned int* s = (unsigned int*)src;
   unsigned int* d = (unsigned int*)dest;
 
-  unsigned int diff = (unsigned int)d - (unsigned int)(s + 1); // extra offset because input gets incremented before output is calculated
+  unsigned int diff = memdiff(d, s + 1); // extra offset because input gets incremented before output is calculated
   // Underflow would be like adding a negative offset
 
   // Can use 'd' as a scratch reg now
@@ -136,7 +141,7 @@ void * memcpy_64bit(void *dest, const void *src, unsigned int len)
 
   _Complex float double_scratch;
 
-  unsigned int diff = (unsigned int)d - (unsigned int)(s + 1); // extra offset because input gets incremented before output is calculated
+  unsigned int diff = memdiff(d, s + 1); // extra offset because input gets incremented before output is calculated
   // Underflow would be like adding a negative offset
 
   asm volatile (
@@ -214,7 +219,7 @@ void * memset_zeroes_64bit(void *dest, unsigned int len)
     return dest;
   }
 
-  _Complex float * d = (_Complex float*)((unsigned int)dest & 0x1fffffff);
+  _Complex float * d = to_p1(dest);
   _Complex float * nextd = d + len;
 
   asm volatile (
@@ -457,7 +462,7 @@ void * SH4_mem_to_pkt_X_movca_32(void *dest, void *src, unsigned int numbytes)
     "mov.l %[scratch_Y], @%[out2]\n\t" // Write data to out2 28 Y (LS 1)
     "add #8, %[out]\n\t" // out is now 32 from prev out (EX 1)
 
-    "mov %[out2], %[scratch_R0]\n\t" // Reuse R0 - Need to purge the cache block just written to because 0x01848000 is volatile and used for both reads and writes (MT 0)
+    "mov %[out2], %[scratch_R0]\n\t" // Reuse R0 - Need to purge the cache block just written to because 0x81848000 is volatile and used for both reads and writes (MT 0)
     "add #-28, %[scratch_R0]\n\t" // Reuse R0 (EX 1) -- flow dependency special case
 
     "ocbp @%[scratch_R0]\n\t" // Reuse R0 (LS 1-5)

--- a/target-src/dcload/memfuncs.h
+++ b/target-src/dcload/memfuncs.h
@@ -97,4 +97,9 @@ static inline void CacheBlockInvalidate(unsigned char * __32_byte_base, unsigned
 	}
 }
 
+static inline void * to_p1(void *addr)
+{
+	return (void *)(((unsigned int)addr & 0x1fffffff) | 0x80000000);
+}
+
 #endif

--- a/target-src/dcload/net.c
+++ b/target-src/dcload/net.c
@@ -125,7 +125,7 @@ static void process_udp(ether_header_t *ether, ip_header_t *ip, udp_header_t *ud
 	// Note that UDP's length field actually includes the UDP header, which is UDP_H_LEN
 	unsigned short udp_data_length = ntohs(udp->length) - UDP_H_LEN;
 
-	pseudo = (ip_udp_pseudo_header_t *)((unsigned int)pseudo_array & 0x1fffffff); // global small pseudo header array
+	pseudo = (ip_udp_pseudo_header_t *)to_p1(pseudo_array); // global small pseudo header array
 	pseudo->src_ip = ip->src;
 	pseudo->dest_ip = ip->dest;
 	pseudo->zero = 0;

--- a/target-src/dcload/packet.c
+++ b/target-src/dcload/packet.c
@@ -91,7 +91,7 @@ __attribute__((aligned(4))) unsigned char pseudo_array[PSEUDO_H_LEN]; // Here's 
 // UDP packet length should always be an even number. It's the length of the UDP payload data specified by the 'data' variable.
 void make_udp(unsigned short dest, unsigned short src, int length, ip_header_t *ip, udp_header_t *udp)
 {
-	ip_udp_pseudo_header_t * pseudo = (ip_udp_pseudo_header_t*)((unsigned int)pseudo_array & 0x1fffffff);
+	ip_udp_pseudo_header_t * pseudo = (ip_udp_pseudo_header_t*)pseudo_array;
 
 	udp->src = htons(src);
 	udp->dest = htons(dest);


### PR DESCRIPTION
Change all addresses to use the P1 memory area instead of the P0 memory area. This means that the P0 area can now be used for memory-mapping, and therefore the applications can now use the MMU.

Fixes #22.