### PR TITLE
MASSIVE performance boost.

### DIFF
--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -1205,9 +1205,9 @@ int do_console(char *path, char *isofile)
 
 	while(recv_response(buffer, PACKET_TIMEOUT) == -1)
 #if (SAVE_MY_FANS != 0)
-  nanosleep(&time, &remain); /* Sleep for 0ns, which is just going to yield the thread. */
+		nanosleep(&time, &remain); /* Sleep for 0ns, which is just going to yield the thread. */
 #else
-  ; /* Spin thread until a packet arrives. */
+		; /* Spin thread until a packet arrives. */
 #endif
 
 	if (!(memcmp(buffer, CMD_EXIT, 4)))

--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -1204,7 +1204,11 @@ int do_console(char *path, char *isofile)
 	fflush(stdout);
 
 	while(recv_response(buffer, PACKET_TIMEOUT) == -1)
-		nanosleep(&time, &remain);
+#if (SAVE_MY_FANS != 0)
+  nanosleep(&time, &remain); /* Sleep for 0ns, which is just going to yield the thread. */
+#else
+  ; /* Spin thread until a packet arrives. */
+#endif
 
 	if (!(memcmp(buffer, CMD_EXIT, 4)))
 	    return -1;
@@ -1250,9 +1254,6 @@ int do_console(char *path, char *isofile)
 	    CatchError(dc_cdfs_redir_read_sectors(isofd, buffer));
 	if (!(memcmp(buffer, CMD_GDBPACKET, 4)))
 	    CatchError(dc_gdbpacket(buffer));
-
-		// reset the timer
-		time.tv_nsec = 500000000;
     }
     if(!(memcmp(buffer, CMD_REWINDDIR, 4)))
         CatchError(dc_rewinddir(buffer));


### PR DESCRIPTION
So here's the deal. Every single time dc-tool saw that no packet was
incoming from the DC, it would sleep FOR A WHOLE GODDAMN HALF SECOND,
which absolutely DESTROYED performance and would make it less stable
too, as the chances of packet loss were higher.

This change removes any sleeping by default (we should be processing
them as quickly as they come), BUT will do a sleep of `0ns` if the
SAVE_MY_FANS flag is enabled--which is simply going to be equivalent to
yielding the thread so we don't hog all the CPU.

About a handful of us have been manually hacking in this perf boost change locally and can confirm it's a massive improvement with no stability issues.