### PR TITLE
Chrootless

### DIFF
--- a/Makefile.cfg
+++ b/Makefile.cfg
@@ -10,7 +10,7 @@ include $(ROOTDIR)/Makefile.hostdetect
 
 # Host compiler and flags
 HOSTCC			= gcc
-HOSTCFLAGS		= -O2 -I/usr/local/include
+HOSTCFLAGS		= -Og -I/usr/local/include -g
 HOSTLDFLAGS		= -L/usr/local/lib
 
 # For MinGW/MSYS, MinGW-w64/MSYS2 and Cygwin

--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -215,7 +215,6 @@ int dcsocket = 0;
 int gdb_server_socket = -1;
 int socket_fd = 0; // For GDB
 int global_socket = 0; // Stores whichever global socket gets used
-unsigned int nochroot = 0;
 char *path = 0;
 #endif
 

--- a/host-src/tool/dc-tool.c
+++ b/host-src/tool/dc-tool.c
@@ -1317,7 +1317,7 @@ int open_gdb_socket(int port)
 }
 
 #ifdef __MINGW32__
-#define AVAILABLE_OPTIONS		"x:u:d:a:s:t:i:nlqhrg"
+#define AVAILABLE_OPTIONS		"x:u:d:a:s:t:m:i:nlqhrg"
 #else
 #define AVAILABLE_OPTIONS		"x:u:d:a:s:t:m:c:i:nlqhrg"
 #endif

--- a/host-src/tool/syscalls.c
+++ b/host-src/tool/syscalls.c
@@ -254,7 +254,7 @@ int dc_link(unsigned char * buffer)
 
     pathname1 = map_path(command->string);
     if (mappath){
-        strcpy(path_buffer2, mappath);
+        strcpy(path_buffer2, pathname1);
         pathname1 = path_buffer2;
     }
     pathname2 = map_path(&command->string[strlen(command->string)+1]);

--- a/host-src/tool/syscalls.c
+++ b/host-src/tool/syscalls.c
@@ -20,27 +20,28 @@
  *
  */
 
-#include <dirent.h>
-#include <errno.h>
+#include <sys/types.h>
+#include <sys/stat.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
 #include <sys/time.h>
-#include <sys/types.h>
-#include <time.h>
 #include <unistd.h>
+#include <time.h>
 #include <utime.h>
+#include <dirent.h>
+#include <string.h>
+#include <errno.h>
 #ifdef __MINGW32__
 #include <windows.h>
 #else
 #include <netinet/in.h>
 #endif
-#include "commands.h"
+#include "syscalls.h"
 #include "dc-io.h"
 #include "dcload-types.h"
-#include "syscalls.h"
+#include "commands.h"
 
 #include "utils.h"
 
@@ -49,13 +50,12 @@
 #endif
 
 #ifndef MAX_OPEN_DIRS
-#define MAX_OPEN_DIRS 16
+#define MAX_OPEN_DIRS   16
 #endif
 
 /* Sigh... KOS treats anything under 100 as invalid for a dirent from dcload, so
    we need to offset by a bit. This aught to do. */
-#define DIRENT_OFFSET 1337
-
+#define DIRENT_OFFSET   1337
 #define MAX_PATH_LEN 4096
 
 static DIR *opendirs[MAX_OPEN_DIRS];
@@ -92,113 +92,119 @@ static inline char *map_path(char *path) {
  * 4. send return value to dc
  */
 
-unsigned int dc_order(unsigned int x) {
-  if (x == htonl(x))
-    return (x << 24) | ((x << 8) & 0xff0000) | ((x >> 8) & 0xff00) |
-           ((x >> 24) & 0xff);
-  else
-    return x;
+unsigned int dc_order(unsigned int x)
+{
+    if (x == htonl(x))
+	return (x << 24) | ((x << 8) & 0xff0000) | ((x >> 8) & 0xff00) | ((x >> 24) & 0xff);
+    else
+	return x;
 }
 
-int dc_fstat(unsigned char *buffer) {
-  struct stat filestat;
-  int retval;
-  dcload_stat_t dcstat;
-  command_3int_t *command = (command_3int_t *)buffer;
-  /* value0 = fd, value1 = addr, value2 = size */
+int dc_fstat(unsigned char * buffer)
+{
+    struct stat filestat;
+    int retval;
+    dcload_stat_t dcstat;
+    command_3int_t *command = (command_3int_t *)buffer;
+    /* value0 = fd, value1 = addr, value2 = size */
 
-  retval = fstat(ntohl(command->value0), &filestat);
+    retval = fstat(ntohl(command->value0), &filestat);
 
-  dcstat.st_dev = dc_order(filestat.st_dev);
-  dcstat.st_ino = dc_order(filestat.st_ino);
-  dcstat.st_mode = dc_order(filestat.st_mode);
-  dcstat.st_nlink = dc_order(filestat.st_nlink);
-  dcstat.st_uid = dc_order(filestat.st_uid);
-  dcstat.st_gid = dc_order(filestat.st_gid);
-  dcstat.st_rdev = dc_order(filestat.st_rdev);
-  dcstat.st_size = dc_order(filestat.st_size);
+    dcstat.st_dev = dc_order(filestat.st_dev);
+    dcstat.st_ino = dc_order(filestat.st_ino);
+    dcstat.st_mode = dc_order(filestat.st_mode);
+    dcstat.st_nlink = dc_order(filestat.st_nlink);
+    dcstat.st_uid = dc_order(filestat.st_uid);
+    dcstat.st_gid = dc_order(filestat.st_gid);
+    dcstat.st_rdev = dc_order(filestat.st_rdev);
+    dcstat.st_size = dc_order(filestat.st_size);
 #ifndef __MINGW32__
-  dcstat.st_blksize = dc_order(filestat.st_blksize);
-  dcstat.st_blocks = dc_order(filestat.st_blocks);
+    dcstat.st_blksize = dc_order(filestat.st_blksize);
+    dcstat.st_blocks = dc_order(filestat.st_blocks);
 #endif
-  dcstat.st_atime_priv = dc_order(filestat.st_atime);
-  dcstat.st_mtime_priv = dc_order(filestat.st_mtime);
-  dcstat.st_ctime_priv = dc_order(filestat.st_ctime);
+    dcstat.st_atime_priv = dc_order(filestat.st_atime);
+    dcstat.st_mtime_priv = dc_order(filestat.st_mtime);
+    dcstat.st_ctime_priv = dc_order(filestat.st_ctime);
 
-  send_data((unsigned char *)&dcstat, ntohl(command->value1),
-            ntohl(command->value2));
+    send_data((unsigned char *)&dcstat, ntohl(command->value1), ntohl(command->value2));
 
-  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-  return 0;
+    return 0;
 }
 
-int dc_write(unsigned char *buffer) {
-  unsigned char *data;
-  int retval;
-  command_3int_t *command = (command_3int_t *)buffer;
-  /* value0 = fd, value1 = addr, value2 = size */
+int dc_write(unsigned char * buffer)
+{
+    unsigned char *data;
+    int retval;
+    command_3int_t *command = (command_3int_t *)buffer;
+    /* value0 = fd, value1 = addr, value2 = size */
 
-  data = malloc(ntohl(command->value2));
+    data = malloc(ntohl(command->value2));
 
-  recv_data(data, ntohl(command->value1), ntohl(command->value2), 1);
+    recv_data(data, ntohl(command->value1), ntohl(command->value2), 1);
 
-  // Check for exception messages. This compare is pretty quick, so it
-  // shouldn't slow anything down unless someone is really pelting the console
-  // hard.. Although, in that case printf() will probably become a big
-  // bottleneck before this memcmp() ever does...
-  if (!(memcmp(data, CMD_EXCEPTION, 4))) {
-    // Exception data starts with "EXPT"
-    exception_struct_t *exception_frame = (exception_struct_t *)data;
-    unsigned int *exception_frame_uints = (unsigned int *)data;
+    // Check for exception messages. This compare is pretty quick, so it
+    // shouldn't slow anything down unless someone is really pelting the console
+    // hard.. Although, in that case printf() will probably become a big
+    // bottleneck before this memcmp() ever does...
+    if(!(memcmp(data, CMD_EXCEPTION, 4)))
+    {
+      // Exception data starts with "EXPT"
+      exception_struct_t *exception_frame = (exception_struct_t*)data;
+      unsigned int *exception_frame_uints = (unsigned int*)data;
 
-    printf("\n\n");
-    printf(exception_code_to_string(exception_frame->expt_code));
-    for (unsigned int regdump = 0; regdump < 66; regdump++) {
-      printf(exception_label_array[regdump]);
-      printf(": 0x%x\n", exception_frame_uints[regdump + 2]);
+      printf("\n\n");
+      printf(exception_code_to_string(exception_frame->expt_code));
+      for(unsigned int regdump = 0; regdump < 66; regdump++)
+      {
+        printf(exception_label_array[regdump]);
+        printf(": 0x%x\n", exception_frame_uints[regdump + 2]);
+      }
+
+      // Write out to a file as well
+      // It will end up in the working directory of the terminal
+      int out_file = open("dcload_exception_dump.bin", O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, 0644);
+      retval = write(out_file, data, ntohl(command->value2));
+      close(out_file);
+    }
+    else
+    {
+      retval = write(ntohl(command->value0), data, ntohl(command->value2));
     }
 
-    // Write out to a file as well
-    // It will end up in the working directory of the terminal
-    int out_file = open("dcload_exception_dump.bin",
-                        O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, 0644);
-    retval = write(out_file, data, ntohl(command->value2));
-    close(out_file);
-  } else {
-    retval = write(ntohl(command->value0), data, ntohl(command->value2));
-  }
+    if(send_command(CMD_RETVAL, retval, retval, NULL, 0) == -1) {
+        free(data);
+        return -1;
+    }
 
-  if (send_command(CMD_RETVAL, retval, retval, NULL, 0) == -1) {
     free(data);
-    return -1;
-  }
-
-  free(data);
-  return 0;
+    return 0;
 }
 
-int dc_read(unsigned char *buffer) {
-  unsigned char *data;
-  int retval;
-  command_3int_t *command = (command_3int_t *)buffer;
-  /* value0 = fd, value1 = addr, value2 = size */
+int dc_read(unsigned char * buffer)
+{
+    unsigned char *data;
+    int retval;
+    command_3int_t *command = (command_3int_t *)buffer;
+    /* value0 = fd, value1 = addr, value2 = size */
 
-  data = malloc(ntohl(command->value2));
-  retval = read(ntohl(command->value0), data, ntohl(command->value2));
+    data = malloc(ntohl(command->value2));
+    retval = read(ntohl(command->value0), data, ntohl(command->value2));
 
-  send_data(data, ntohl(command->value1), ntohl(command->value2));
+    send_data(data, ntohl(command->value1), ntohl(command->value2));
 
-  if (send_command(CMD_RETVAL, retval, retval, NULL, 0)) {
+    if(send_command(CMD_RETVAL, retval, retval, NULL, 0)) {
+        free(data);
+        return -1;
+    }
+
     free(data);
-    return -1;
-  }
-
-  free(data);
-  return 0;
+    return 0;
 }
 
-int dc_open(unsigned char *buffer) {
+int dc_open(unsigned char * buffer)
+{
   int retval;
   int ourflags = 0;
   command_2int_string_t *command = (command_2int_string_t *)buffer;
@@ -226,32 +232,35 @@ int dc_open(unsigned char *buffer) {
   return 0;
 }
 
-int dc_close(unsigned char *buffer) {
-  int retval;
-  command_int_t *command = (command_int_t *)buffer;
+int dc_close(unsigned char * buffer)
+{
+    int retval;
+    command_int_t *command = (command_int_t *)buffer;
 
-  retval = close(ntohl(command->value0));
+    retval = close(ntohl(command->value0));
 
-  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-  return 0;
+    return 0;
 }
 
-int dc_creat(unsigned char *buffer) {
-  int retval;
-  command_int_string_t *command = (command_int_string_t *)buffer;
+int dc_creat(unsigned char * buffer)
+{
+    int retval;
+    command_int_string_t *command = (command_int_string_t *)buffer;
 
   retval = creat(map_path(command->string), ntohl(command->value0));
 
-  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-  return 0;
+    return 0;
 }
 
-int dc_link(unsigned char *buffer) {
-  int retval;
-  command_string_t *command = (command_string_t *)buffer;
-  char local_buffer[MAX_PATH_LEN];
+int dc_link(unsigned char * buffer)
+{
+    char *pathname1, *pathname2;
+    int retval;
+    command_string_t *command = (command_string_t *)buffer;
 
   char *local_ref = map_path(command->string);
   if (mappath) {
@@ -259,243 +268,255 @@ int dc_link(unsigned char *buffer) {
   }
 
 #ifdef __MINGW32__
-  /* Copy the file on Windows */
-  retval = CopyFileA(
-      local_buffer, map_path(&command->string[strlen(command->string) + 1]), 0);
+    /* Copy the file on Windows */
+    retval = CopyFileA(pathname1, pathname2, 0);
 #else
-  retval = link(local_buffer,
-                map_path(&command->string[strlen(command->string) + 1]));
+    retval = link(pathname1, pathname2);
 #endif
 
-  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-  return 0;
+    return 0;
 }
 
-int dc_unlink(unsigned char *buffer) {
-  int retval;
-  command_string_t *command = (command_string_t *)buffer;
+int dc_unlink(unsigned char * buffer)
+{
+    int retval;
+    command_string_t *command = (command_string_t *)buffer;
 
-  retval = unlink(map_path(command->string));
-  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+    retval = unlink(command->string);
 
-  return 0;
+    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+
+    return 0;
 }
 
-int dc_chdir(unsigned char *buffer) {
-  int retval;
-  command_string_t *command = (command_string_t *)buffer;
+int dc_chdir(unsigned char * buffer)
+{
+    int retval;
+    command_string_t *command = (command_string_t *)buffer;
 
-  retval = chdir(map_path(command->string));
+    retval = chdir(map_path(command->string));
 
-  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-  return 0;
+    return 0;
 }
 
-int dc_chmod(unsigned char *buffer) {
-  int retval;
-  command_int_string_t *command = (command_int_string_t *)buffer;
+int dc_chmod(unsigned char * buffer)
+{
+    int retval;
+    command_int_string_t *command = (command_int_string_t *)buffer;
 
-  retval = chmod(command->string, ntohl(command->value0));
+  retval = chmod(map_path(command->string), ntohl(command->value0));
 
-  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-  return 0;
+    return 0;
 }
 
-int dc_lseek(unsigned char *buffer) {
-  int retval;
-  command_3int_t *command = (command_3int_t *)buffer;
+int dc_lseek(unsigned char * buffer)
+{
+    int retval;
+    command_3int_t *command = (command_3int_t *)buffer;
 
-  retval = lseek(ntohl(command->value0), ntohl(command->value1),
-                 ntohl(command->value2));
+    retval = lseek(ntohl(command->value0), ntohl(command->value1), ntohl(command->value2));
 
-  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-  return 0;
+    return 0;
 }
 
-int dc_time(unsigned char *buffer) {
-  time_t t = time(NULL);
+int dc_time(unsigned char * buffer)
+{
+    time_t t = time(NULL);
 
-  send_cmd(CMD_RETVAL, t, t, NULL, 0);
+    send_cmd(CMD_RETVAL, t, t, NULL, 0);
 
-  return 0;
+    return 0;
 }
 
-int dc_stat(unsigned char *buffer) {
-  struct stat filestat;
-  int retval;
-  dcload_stat_t dcstat;
-  command_2int_string_t *command = (command_2int_string_t *)buffer;
+int dc_stat(unsigned char * buffer)
+{
+    struct stat filestat;
+    int retval;
+    dcload_stat_t dcstat;
+    command_2int_string_t *command = (command_2int_string_t *)buffer;
 
   retval = stat(map_path(command->string), &filestat);
 
-  dcstat.st_dev = dc_order(filestat.st_dev);
-  dcstat.st_ino = dc_order(filestat.st_ino);
-  dcstat.st_mode = dc_order(filestat.st_mode);
-  dcstat.st_nlink = dc_order(filestat.st_nlink);
-  dcstat.st_uid = dc_order(filestat.st_uid);
-  dcstat.st_gid = dc_order(filestat.st_gid);
-  dcstat.st_rdev = dc_order(filestat.st_rdev);
-  dcstat.st_size = dc_order(filestat.st_size);
+    dcstat.st_dev = dc_order(filestat.st_dev);
+    dcstat.st_ino = dc_order(filestat.st_ino);
+    dcstat.st_mode = dc_order(filestat.st_mode);
+    dcstat.st_nlink = dc_order(filestat.st_nlink);
+    dcstat.st_uid = dc_order(filestat.st_uid);
+    dcstat.st_gid = dc_order(filestat.st_gid);
+    dcstat.st_rdev = dc_order(filestat.st_rdev);
+    dcstat.st_size = dc_order(filestat.st_size);
 #ifndef __MINGW32__
-  dcstat.st_blksize = dc_order(filestat.st_blksize);
-  dcstat.st_blocks = dc_order(filestat.st_blocks);
+    dcstat.st_blksize = dc_order(filestat.st_blksize);
+    dcstat.st_blocks = dc_order(filestat.st_blocks);
 #endif
-  dcstat.st_atime_priv = dc_order(filestat.st_atime);
-  dcstat.st_mtime_priv = dc_order(filestat.st_mtime);
-  dcstat.st_ctime_priv = dc_order(filestat.st_ctime);
+    dcstat.st_atime_priv = dc_order(filestat.st_atime);
+    dcstat.st_mtime_priv = dc_order(filestat.st_mtime);
+    dcstat.st_ctime_priv = dc_order(filestat.st_ctime);
 
-  send_data((unsigned char *)&dcstat, ntohl(command->value0),
-            ntohl(command->value1));
+    send_data((unsigned char *)&dcstat, ntohl(command->value0), ntohl(command->value1));
 
-  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-  return 0;
-}
-
-int dc_utime(unsigned char *buffer) {
-  struct utimbuf tbuf;
-  int retval;
-  command_3int_string_t *command = (command_3int_string_t *)buffer;
-
-  if (ntohl(command->value0)) {
-    tbuf.actime = ntohl(command->value1);
-    tbuf.modtime = ntohl(command->value2);
-
-    retval = utime(map_path(command->string), &tbuf);
-  } else {
-    retval = utime(map_path(command->string), 0);
-  }
-  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
-
-  return 0;
-}
-
-int dc_opendir(unsigned char *buffer) {
-  DIR *somedir;
-  command_string_t *command = (command_string_t *)buffer;
-  int i;
-
-  /* Find an open entry */
-  for (i = 0; i < MAX_OPEN_DIRS; ++i) {
-    if (!opendirs[i])
-      break;
-  }
-
-  if (i < MAX_OPEN_DIRS) {
-    if (!(opendirs[i] = opendir(map_path(command->string))))
-      i = 0;
-    else
-      i += DIRENT_OFFSET;
-  } else {
-    i = 0;
-  }
-
-  send_cmd(CMD_RETVAL, (unsigned int)i, (unsigned int)i, NULL, 0);
-
-  return 0;
-}
-
-int dc_closedir(unsigned char *buffer) {
-  int retval;
-  command_int_t *command = (command_int_t *)buffer;
-  uint32_t i = ntohl(command->value0);
-
-  if (i >= DIRENT_OFFSET && i < MAX_OPEN_DIRS + DIRENT_OFFSET) {
-    retval = closedir(opendirs[i - DIRENT_OFFSET]);
-    opendirs[i - DIRENT_OFFSET] = NULL;
-  } else {
-    retval = -1;
-  }
-
-  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
-
-  return 0;
-}
-
-int dc_readdir(unsigned char *buffer) {
-  struct dirent *somedirent;
-  dcload_dirent_t dcdirent;
-  command_3int_t *command = (command_3int_t *)buffer;
-  uint32_t i = ntohl(command->value0);
-
-  if (i >= DIRENT_OFFSET && i < MAX_OPEN_DIRS + DIRENT_OFFSET)
-    somedirent = readdir(opendirs[i - DIRENT_OFFSET]);
-  else
-    somedirent = NULL;
-
-  if (somedirent) {
-#if defined(__APPLE__) || defined(__NetBSD__) || defined(__FreeBSD__) ||       \
-    defined(__OpenBSD__)
-    dcdirent.d_ino = dc_order(somedirent->d_fileno);
-    dcdirent.d_off = dc_order(0);
-    dcdirent.d_reclen = dc_order(somedirent->d_reclen);
-    dcdirent.d_type = dc_order(somedirent->d_type);
-#else
-    dcdirent.d_ino = dc_order(somedirent->d_ino);
-#if defined(_WIN32) || defined(__CYGWIN__)
-    dcdirent.d_off = dc_order(0);
-    dcdirent.d_reclen = dc_order(0);
-    dcdirent.d_type = dc_order(0);
-#else
-    dcdirent.d_off = dc_order(somedirent->d_off);
-    dcdirent.d_reclen = dc_order(somedirent->d_reclen);
-    dcdirent.d_type = dc_order(somedirent->d_type);
-#endif
-#endif
-    strcpy(dcdirent.d_name, somedirent->d_name);
-
-    send_data((unsigned char *)&dcdirent, ntohl(command->value1),
-              ntohl(command->value2));
-    send_cmd(CMD_RETVAL, 1, 1, NULL, 0);
     return 0;
-  }
-
-  send_cmd(CMD_RETVAL, 0, 0, NULL, 0);
-
-  return 0;
 }
 
-int dc_rewinddir(unsigned char *buffer) {
-  int retval;
-  command_int_t *command = (command_int_t *)buffer;
-  uint32_t i = ntohl(command->value0);
+int dc_utime(unsigned char * buffer)
+{
+    struct utimbuf tbuf;
+    int retval;
+    command_3int_string_t *command = (command_3int_string_t *)buffer;
 
-  if (i >= DIRENT_OFFSET && i < MAX_OPEN_DIRS + DIRENT_OFFSET) {
-    rewinddir(opendirs[i - DIRENT_OFFSET]);
-    opendirs[i - DIRENT_OFFSET] = NULL;
-    retval = 0;
-  } else {
-    retval = -1;
-  }
+    if (ntohl(command->value0)) {
+	tbuf.actime = ntohl(command->value1);
+	tbuf.modtime = ntohl(command->value2);
 
-  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+	retval = utime(command->string, &tbuf);
+    } else {
+	retval = utime(command->string, 0);
+    }
+    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-  return 0;
+    return 0;
 }
 
-int dc_cdfs_redir_read_sectors(int isofd, unsigned char *buffer) {
-  int start;
-  unsigned char *buf;
-  command_3int_t *command = (command_3int_t *)buffer;
+int dc_opendir(unsigned char * buffer)
+{
+    DIR *somedir;
+    command_string_t *command = (command_string_t *)buffer;
+    int i;
 
-  start = ntohl(command->value0) - 150;
+    /* Find an open entry */
+    for(i = 0; i < MAX_OPEN_DIRS; ++i) {
+        if(!opendirs[i])
+            break;
+    }
 
-  lseek(isofd, start * 2048, SEEK_SET);
+    if(i < MAX_OPEN_DIRS) {
+    if (!(opendirs[i] = opendir(map_path(command->string))))
+            i = 0;
+        else
+            i += DIRENT_OFFSET;
+    }
+    else {
+        i = 0;
+    }
 
-  buf = malloc(ntohl(command->value2));
+    send_cmd(CMD_RETVAL, (unsigned int)i, (unsigned int)i, NULL, 0);
 
-  read(isofd, buf, ntohl(command->value2));
+    return 0;
+}
 
-  send_data(buf, ntohl(command->value1), ntohl(command->value2));
+int dc_closedir(unsigned char * buffer)
+{
+    int retval;
+    command_int_t *command = (command_int_t *)buffer;
+    uint32_t i = ntohl(command->value0);
 
-  send_cmd(CMD_RETVAL, 0, 0, NULL, 0);
 
-  free(buf);
-  return 0;
+    if(i >= DIRENT_OFFSET && i < MAX_OPEN_DIRS + DIRENT_OFFSET) {
+        retval = closedir(opendirs[i - DIRENT_OFFSET]);
+        opendirs[i - DIRENT_OFFSET] = NULL;
+    }
+    else {
+        retval = -1;
+    }
+
+    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+
+    return 0;
+}
+
+int dc_readdir(unsigned char * buffer)
+{
+    struct dirent *somedirent;
+    dcload_dirent_t dcdirent;
+    command_3int_t *command = (command_3int_t *)buffer;
+    uint32_t i = ntohl(command->value0);
+
+    if(i >= DIRENT_OFFSET && i < MAX_OPEN_DIRS + DIRENT_OFFSET)
+        somedirent = readdir(opendirs[i - DIRENT_OFFSET]);
+    else
+        somedirent = NULL;
+
+    if (somedirent) {
+#if defined (__APPLE__) || defined (__NetBSD__) || defined (__FreeBSD__) || defined (__OpenBSD__)
+	dcdirent.d_ino = dc_order(somedirent->d_fileno);
+	dcdirent.d_off = dc_order(0);
+	dcdirent.d_reclen = dc_order(somedirent->d_reclen);
+	dcdirent.d_type = dc_order(somedirent->d_type);
+#else
+	dcdirent.d_ino = dc_order(somedirent->d_ino);
+# if defined(_WIN32) || defined(__CYGWIN__)
+	dcdirent.d_off = dc_order(0);
+	dcdirent.d_reclen = dc_order(0);
+	dcdirent.d_type = dc_order(0);
+# else
+	dcdirent.d_off = dc_order(somedirent->d_off);
+	dcdirent.d_reclen = dc_order(somedirent->d_reclen);
+	dcdirent.d_type = dc_order(somedirent->d_type);
+# endif
+#endif
+	strcpy(dcdirent.d_name, somedirent->d_name);
+
+	send_data((unsigned char *)&dcdirent, ntohl(command->value1), ntohl(command->value2));
+	send_cmd(CMD_RETVAL, 1, 1, NULL, 0);
+	return 0;
+    }
+
+    send_cmd(CMD_RETVAL, 0, 0, NULL, 0);
+
+    return 0;
+}
+
+int dc_rewinddir(unsigned char * buffer)
+{
+    int retval;
+    command_int_t *command = (command_int_t *)buffer;
+    uint32_t i = ntohl(command->value0);
+
+
+    if(i >= DIRENT_OFFSET && i < MAX_OPEN_DIRS + DIRENT_OFFSET) {
+        rewinddir(opendirs[i - DIRENT_OFFSET]);
+        opendirs[i - DIRENT_OFFSET] = NULL;
+        retval = 0;
+    }
+    else {
+        retval = -1;
+    }
+
+    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+
+    return 0;
+}
+
+int dc_cdfs_redir_read_sectors(int isofd, unsigned char * buffer)
+{
+    int start;
+    unsigned char * buf;
+    command_3int_t *command = (command_3int_t *)buffer;
+
+    start = ntohl(command->value0) - 150;
+
+    lseek(isofd, start * 2048, SEEK_SET);
+
+    buf = malloc(ntohl(command->value2));
+
+    read(isofd, buf, ntohl(command->value2));
+
+    send_data(buf, ntohl(command->value1), ntohl(command->value2));
+
+    send_cmd(CMD_RETVAL, 0, 0, NULL, 0);
+
+    free(buf);
+    return 0;
 }
 
 #define GDBBUFSIZE 1024
@@ -507,59 +528,59 @@ extern int gdb_server_socket;
 extern int socket_fd;
 #endif
 
-int dc_gdbpacket(unsigned char *buffer) {
-  size_t in_size, out_size;
-  static char gdb_buf[GDBBUFSIZE];
-  int retval = 0;
+int dc_gdbpacket(unsigned char * buffer)
+{
+    size_t in_size, out_size;
+    static char gdb_buf[GDBBUFSIZE];
+    int retval = 0;
 
 #ifdef __MINGW32__
-  if (gdb_server_socket == INVALID_SOCKET) {
+	if (gdb_server_socket == INVALID_SOCKET) {
 #else
-  if (gdb_server_socket < 0) {
+	if (gdb_server_socket < 0) {
 #endif
-    send_cmd(CMD_RETVAL, -1, -1, NULL, 0);
-  }
+        send_cmd(CMD_RETVAL, -1, -1, NULL, 0);
+    }
 
-  if (socket_fd == 0) {
-    printf("waiting for gdb client connection...\n");
-    socket_fd = accept(gdb_server_socket, NULL, NULL);
+    if (socket_fd == 0) {
+	printf( "waiting for gdb client connection...\n" );
+	socket_fd = accept( gdb_server_socket, NULL, NULL );
 #ifdef __MINGW32__
-    if (socket_fd != INVALID_SOCKET)
+	if ( socket_fd != INVALID_SOCKET)
 #endif
-      if (socket_fd == 0) {
-        log_error("error accepting gdb server connection");
+	if ( socket_fd == 0) {
+	    log_error("error accepting gdb server connection");
+	    return -1;
+	}
+    }
+
+    command_2int_string_t *command = (command_2int_string_t *)buffer;
+    /* value0 = in_size, value1 = out_size, string = packet */
+
+    in_size = ntohl(command->value0);
+    out_size = ntohl(command->value1);
+
+    if (in_size)
+	send(socket_fd, command->string, in_size, 0);
+
+    if (out_size) {
+	retval = recv(socket_fd, gdb_buf, out_size > GDBBUFSIZE ? GDBBUFSIZE : out_size, 0);
+
+	if (retval == 0)
+	socket_fd = -1;
+    }
+#ifdef __MINGW32__
+	if(retval == SOCKET_ERROR) {
+	fprintf(stderr, "Got socket error: %d\n", WSAGetLastError());
+	return -1;
+	}
+#else
+    if(retval == -1) {
+        fprintf(stderr, "Got socket error: %s\n", strerror(errno));
         return -1;
-      }
-  }
-
-  command_2int_string_t *command = (command_2int_string_t *)buffer;
-  /* value0 = in_size, value1 = out_size, string = packet */
-
-  in_size = ntohl(command->value0);
-  out_size = ntohl(command->value1);
-
-  if (in_size)
-    send(socket_fd, command->string, in_size, 0);
-
-  if (out_size) {
-    retval = recv(socket_fd, gdb_buf,
-                  out_size > GDBBUFSIZE ? GDBBUFSIZE : out_size, 0);
-
-    if (retval == 0)
-      socket_fd = -1;
-  }
-#ifdef __MINGW32__
-  if (retval == SOCKET_ERROR) {
-    fprintf(stderr, "Got socket error: %d\n", WSAGetLastError());
-    return -1;
-  }
-#else
-  if (retval == -1) {
-    fprintf(stderr, "Got socket error: %s\n", strerror(errno));
-    return -1;
-  }
+    }
 #endif
-  send_cmd(CMD_RETVAL, retval, retval, (unsigned char *)gdb_buf, retval);
+    send_cmd(CMD_RETVAL, retval, retval, (unsigned char *)gdb_buf, retval);
 
-  return 0;
+    return 0;
 }

--- a/host-src/tool/syscalls.c
+++ b/host-src/tool/syscalls.c
@@ -20,27 +20,27 @@
  *
  */
 
-#include <sys/types.h>
-#include <sys/stat.h>
+#include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <sys/time.h>
-#include <unistd.h>
-#include <time.h>
-#include <utime.h>
-#include <dirent.h>
 #include <string.h>
-#include <errno.h>
+#include <sys/stat.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+#include <utime.h>
 #ifdef __MINGW32__
 #include <windows.h>
 #else
 #include <netinet/in.h>
 #endif
-#include "syscalls.h"
+#include "commands.h"
 #include "dc-io.h"
 #include "dcload-types.h"
-#include "commands.h"
+#include "syscalls.h"
 
 #include "utils.h"
 
@@ -49,15 +49,14 @@
 #endif
 
 #ifndef MAX_OPEN_DIRS
-#define MAX_OPEN_DIRS   16
+#define MAX_OPEN_DIRS 16
 #endif
 
 /* Sigh... KOS treats anything under 100 as invalid for a dirent from dcload, so
    we need to offset by a bit. This aught to do. */
-#define DIRENT_OFFSET   1337
+#define DIRENT_OFFSET 1337
 
 #define MAX_PATH_LEN 4096
-
 
 static DIR *opendirs[MAX_OPEN_DIRS];
 static char *mappath = NULL;
@@ -65,22 +64,24 @@ static int mappatlen = -1;
 
 static char path_work_buffer[MAX_PATH_LEN];
 static char path_result_buffer[MAX_PATH_LEN];
-void set_mappath(char *path){
-    mappath = path;
-    mappatlen = strlen(mappath);
-    strcpy(path_work_buffer, mappath);
+void set_mappath(char *path) {
+  mappath = path;
+  mappatlen = strlen(mappath);
+  strcpy(path_work_buffer, mappath);
 }
 
-static inline char* map_path(char *path){
-    if(!mappath)
-        return path;
+static inline char *map_path(char *path) {
+  if (!mappath)
+    return path;
 
-    strcpy(path_work_buffer + mappatlen, path);
-    realpath(path_work_buffer, path_result_buffer);
-    if (strncmp(mappath, path_result_buffer, mappatlen) != 0){
-        return NULL;
-    }
-    return path_result_buffer;
+  strcpy(path_work_buffer + mappatlen, path);
+  realpath(path_work_buffer, path_result_buffer);
+  if (strncmp(mappath, path_result_buffer, mappatlen) != 0) {
+    printf("Requested path:\n\t%s\n"
+    "is outside of basepath:\n\t%s\n", mappath, path_result_buffer);
+    return NULL;
+  }
+  return path_result_buffer;
 }
 
 /* syscalls for dcload-ip
@@ -91,119 +92,113 @@ static inline char* map_path(char *path){
  * 4. send return value to dc
  */
 
-unsigned int dc_order(unsigned int x)
-{
-    if (x == htonl(x))
-	return (x << 24) | ((x << 8) & 0xff0000) | ((x >> 8) & 0xff00) | ((x >> 24) & 0xff);
-    else
-	return x;
+unsigned int dc_order(unsigned int x) {
+  if (x == htonl(x))
+    return (x << 24) | ((x << 8) & 0xff0000) | ((x >> 8) & 0xff00) |
+           ((x >> 24) & 0xff);
+  else
+    return x;
 }
 
-int dc_fstat(unsigned char * buffer)
-{
-    struct stat filestat;
-    int retval;
-    dcload_stat_t dcstat;
-    command_3int_t *command = (command_3int_t *)buffer;
-    /* value0 = fd, value1 = addr, value2 = size */
+int dc_fstat(unsigned char *buffer) {
+  struct stat filestat;
+  int retval;
+  dcload_stat_t dcstat;
+  command_3int_t *command = (command_3int_t *)buffer;
+  /* value0 = fd, value1 = addr, value2 = size */
 
-    retval = fstat(ntohl(command->value0), &filestat);
+  retval = fstat(ntohl(command->value0), &filestat);
 
-    dcstat.st_dev = dc_order(filestat.st_dev);
-    dcstat.st_ino = dc_order(filestat.st_ino);
-    dcstat.st_mode = dc_order(filestat.st_mode);
-    dcstat.st_nlink = dc_order(filestat.st_nlink);
-    dcstat.st_uid = dc_order(filestat.st_uid);
-    dcstat.st_gid = dc_order(filestat.st_gid);
-    dcstat.st_rdev = dc_order(filestat.st_rdev);
-    dcstat.st_size = dc_order(filestat.st_size);
+  dcstat.st_dev = dc_order(filestat.st_dev);
+  dcstat.st_ino = dc_order(filestat.st_ino);
+  dcstat.st_mode = dc_order(filestat.st_mode);
+  dcstat.st_nlink = dc_order(filestat.st_nlink);
+  dcstat.st_uid = dc_order(filestat.st_uid);
+  dcstat.st_gid = dc_order(filestat.st_gid);
+  dcstat.st_rdev = dc_order(filestat.st_rdev);
+  dcstat.st_size = dc_order(filestat.st_size);
 #ifndef __MINGW32__
-    dcstat.st_blksize = dc_order(filestat.st_blksize);
-    dcstat.st_blocks = dc_order(filestat.st_blocks);
+  dcstat.st_blksize = dc_order(filestat.st_blksize);
+  dcstat.st_blocks = dc_order(filestat.st_blocks);
 #endif
-    dcstat.st_atime_priv = dc_order(filestat.st_atime);
-    dcstat.st_mtime_priv = dc_order(filestat.st_mtime);
-    dcstat.st_ctime_priv = dc_order(filestat.st_ctime);
+  dcstat.st_atime_priv = dc_order(filestat.st_atime);
+  dcstat.st_mtime_priv = dc_order(filestat.st_mtime);
+  dcstat.st_ctime_priv = dc_order(filestat.st_ctime);
 
-    send_data((unsigned char *)&dcstat, ntohl(command->value1), ntohl(command->value2));
+  send_data((unsigned char *)&dcstat, ntohl(command->value1),
+            ntohl(command->value2));
 
-    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-    return 0;
+  return 0;
 }
 
-int dc_write(unsigned char * buffer)
-{
-    unsigned char *data;
-    int retval;
-    command_3int_t *command = (command_3int_t *)buffer;
-    /* value0 = fd, value1 = addr, value2 = size */
+int dc_write(unsigned char *buffer) {
+  unsigned char *data;
+  int retval;
+  command_3int_t *command = (command_3int_t *)buffer;
+  /* value0 = fd, value1 = addr, value2 = size */
 
-    data = malloc(ntohl(command->value2));
+  data = malloc(ntohl(command->value2));
 
-    recv_data(data, ntohl(command->value1), ntohl(command->value2), 1);
+  recv_data(data, ntohl(command->value1), ntohl(command->value2), 1);
 
-    // Check for exception messages. This compare is pretty quick, so it
-    // shouldn't slow anything down unless someone is really pelting the console
-    // hard.. Although, in that case printf() will probably become a big
-    // bottleneck before this memcmp() ever does...
-    if(!(memcmp(data, CMD_EXCEPTION, 4)))
-    {
-      // Exception data starts with "EXPT"
-      exception_struct_t *exception_frame = (exception_struct_t*)data;
-      unsigned int *exception_frame_uints = (unsigned int*)data;
+  // Check for exception messages. This compare is pretty quick, so it
+  // shouldn't slow anything down unless someone is really pelting the console
+  // hard.. Although, in that case printf() will probably become a big
+  // bottleneck before this memcmp() ever does...
+  if (!(memcmp(data, CMD_EXCEPTION, 4))) {
+    // Exception data starts with "EXPT"
+    exception_struct_t *exception_frame = (exception_struct_t *)data;
+    unsigned int *exception_frame_uints = (unsigned int *)data;
 
-      printf("\n\n");
-      printf(exception_code_to_string(exception_frame->expt_code));
-      for(unsigned int regdump = 0; regdump < 66; regdump++)
-      {
-        printf(exception_label_array[regdump]);
-        printf(": 0x%x\n", exception_frame_uints[regdump + 2]);
-      }
-
-      // Write out to a file as well
-      // It will end up in the working directory of the terminal
-      int out_file = open("dcload_exception_dump.bin", O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, 0644);
-      retval = write(out_file, data, ntohl(command->value2));
-      close(out_file);
-    }
-    else
-    {
-      retval = write(ntohl(command->value0), data, ntohl(command->value2));
+    printf("\n\n");
+    printf(exception_code_to_string(exception_frame->expt_code));
+    for (unsigned int regdump = 0; regdump < 66; regdump++) {
+      printf(exception_label_array[regdump]);
+      printf(": 0x%x\n", exception_frame_uints[regdump + 2]);
     }
 
-    if(send_command(CMD_RETVAL, retval, retval, NULL, 0) == -1) {
-        free(data);
-        return -1;
-    }
+    // Write out to a file as well
+    // It will end up in the working directory of the terminal
+    int out_file = open("dcload_exception_dump.bin",
+                        O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, 0644);
+    retval = write(out_file, data, ntohl(command->value2));
+    close(out_file);
+  } else {
+    retval = write(ntohl(command->value0), data, ntohl(command->value2));
+  }
 
+  if (send_command(CMD_RETVAL, retval, retval, NULL, 0) == -1) {
     free(data);
-    return 0;
+    return -1;
+  }
+
+  free(data);
+  return 0;
 }
 
-int dc_read(unsigned char * buffer)
-{
-    unsigned char *data;
-    int retval;
-    command_3int_t *command = (command_3int_t *)buffer;
-    /* value0 = fd, value1 = addr, value2 = size */
+int dc_read(unsigned char *buffer) {
+  unsigned char *data;
+  int retval;
+  command_3int_t *command = (command_3int_t *)buffer;
+  /* value0 = fd, value1 = addr, value2 = size */
 
-    data = malloc(ntohl(command->value2));
-    retval = read(ntohl(command->value0), data, ntohl(command->value2));
+  data = malloc(ntohl(command->value2));
+  retval = read(ntohl(command->value0), data, ntohl(command->value2));
 
-    send_data(data, ntohl(command->value1), ntohl(command->value2));
+  send_data(data, ntohl(command->value1), ntohl(command->value2));
 
-    if(send_command(CMD_RETVAL, retval, retval, NULL, 0)) {
-        free(data);
-        return -1;
-    }
-
+  if (send_command(CMD_RETVAL, retval, retval, NULL, 0)) {
     free(data);
-    return 0;
+    return -1;
+  }
+
+  free(data);
+  return 0;
 }
 
-int dc_open(unsigned char * buffer)
-{
+int dc_open(unsigned char *buffer) {
   int retval;
   int ourflags = 0;
   command_2int_string_t *command = (command_2int_string_t *)buffer;
@@ -223,298 +218,284 @@ int dc_open(unsigned char * buffer)
     ourflags |= O_TRUNC;
   if (ntohl(command->value0) & 0x0800)
     ourflags |= O_EXCL;
-
-  retval = open(map_path(command->string), ourflags | O_BINARY, ntohl(command->value1));
+  retval = open(map_path(command->string), ourflags | O_BINARY,
+                ntohl(command->value1));
 
   send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
   return 0;
 }
 
-int dc_close(unsigned char * buffer)
-{
-    int retval;
-    command_int_t *command = (command_int_t *)buffer;
+int dc_close(unsigned char *buffer) {
+  int retval;
+  command_int_t *command = (command_int_t *)buffer;
 
-    retval = close(ntohl(command->value0));
+  retval = close(ntohl(command->value0));
 
-    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-    return 0;
+  return 0;
 }
 
-int dc_creat(unsigned char * buffer)
-{
-    int retval;
-    command_int_string_t *command = (command_int_string_t *)buffer;
+int dc_creat(unsigned char *buffer) {
+  int retval;
+  command_int_string_t *command = (command_int_string_t *)buffer;
 
-    retval = creat(map_path(command->string), ntohl(command->value0));
+  retval = creat(map_path(command->string), ntohl(command->value0));
 
-    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-    return 0;
+  return 0;
 }
 
-int dc_link(unsigned char * buffer)
-{
-    int retval;
-    command_string_t *command = (command_string_t *)buffer;
-    char local_buffer[MAX_PATH_LEN];
+int dc_link(unsigned char *buffer) {
+  int retval;
+  command_string_t *command = (command_string_t *)buffer;
+  char local_buffer[MAX_PATH_LEN];
 
-    char *local_ref = map_path(command->string);
-    if (mappath){
-        strcpy(local_buffer, local_ref);
-    }
+  char *local_ref = map_path(command->string);
+  if (mappath) {
+    strcpy(local_buffer, local_ref);
+  }
 
 #ifdef __MINGW32__
-    /* Copy the file on Windows */
-    retval = CopyFileA(local_buffer, map_path(&command->string[strlen(command->string)+1]), 0);
+  /* Copy the file on Windows */
+  retval = CopyFileA(
+      local_buffer, map_path(&command->string[strlen(command->string) + 1]), 0);
 #else
-    retval = link(local_buffer, map_path(&command->string[strlen(command->string)+1]));
+  retval = link(local_buffer,
+                map_path(&command->string[strlen(command->string) + 1]));
 #endif
 
-    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-    return 0;
+  return 0;
 }
 
-int dc_unlink(unsigned char * buffer)
-{
-    int retval;
-    command_string_t *command = (command_string_t *)buffer;
+int dc_unlink(unsigned char *buffer) {
+  int retval;
+  command_string_t *command = (command_string_t *)buffer;
 
-    retval = unlink(map_path(command->string));
-    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+  retval = unlink(map_path(command->string));
+  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-    return 0;
+  return 0;
 }
 
-int dc_chdir(unsigned char * buffer)
-{
-    int retval;
-    command_string_t *command = (command_string_t *)buffer;
+int dc_chdir(unsigned char *buffer) {
+  int retval;
+  command_string_t *command = (command_string_t *)buffer;
 
-    retval = chdir(map_path(command->string));
+  retval = chdir(map_path(command->string));
 
-    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-    return 0;
+  return 0;
 }
 
-int dc_chmod(unsigned char * buffer)
-{
-    int retval;
-    command_int_string_t *command = (command_int_string_t *)buffer;
+int dc_chmod(unsigned char *buffer) {
+  int retval;
+  command_int_string_t *command = (command_int_string_t *)buffer;
 
-    retval = chmod(command->string, ntohl(command->value0));
+  retval = chmod(command->string, ntohl(command->value0));
 
-    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-    return 0;
+  return 0;
 }
 
-int dc_lseek(unsigned char * buffer)
-{
-    int retval;
-    command_3int_t *command = (command_3int_t *)buffer;
+int dc_lseek(unsigned char *buffer) {
+  int retval;
+  command_3int_t *command = (command_3int_t *)buffer;
 
-    retval = lseek(ntohl(command->value0), ntohl(command->value1), ntohl(command->value2));
+  retval = lseek(ntohl(command->value0), ntohl(command->value1),
+                 ntohl(command->value2));
 
-    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-    return 0;
+  return 0;
 }
 
-int dc_time(unsigned char * buffer)
-{
-    time_t t = time(NULL);
+int dc_time(unsigned char *buffer) {
+  time_t t = time(NULL);
 
-    send_cmd(CMD_RETVAL, t, t, NULL, 0);
+  send_cmd(CMD_RETVAL, t, t, NULL, 0);
 
-    return 0;
+  return 0;
 }
 
-int dc_stat(unsigned char * buffer)
-{
-    struct stat filestat;
-    int retval;
-    dcload_stat_t dcstat;
-    command_2int_string_t *command = (command_2int_string_t *)buffer;
+int dc_stat(unsigned char *buffer) {
+  struct stat filestat;
+  int retval;
+  dcload_stat_t dcstat;
+  command_2int_string_t *command = (command_2int_string_t *)buffer;
 
-    retval = stat(map_path(command->string), &filestat);
+  retval = stat(map_path(command->string), &filestat);
 
-    dcstat.st_dev = dc_order(filestat.st_dev);
-    dcstat.st_ino = dc_order(filestat.st_ino);
-    dcstat.st_mode = dc_order(filestat.st_mode);
-    dcstat.st_nlink = dc_order(filestat.st_nlink);
-    dcstat.st_uid = dc_order(filestat.st_uid);
-    dcstat.st_gid = dc_order(filestat.st_gid);
-    dcstat.st_rdev = dc_order(filestat.st_rdev);
-    dcstat.st_size = dc_order(filestat.st_size);
+  dcstat.st_dev = dc_order(filestat.st_dev);
+  dcstat.st_ino = dc_order(filestat.st_ino);
+  dcstat.st_mode = dc_order(filestat.st_mode);
+  dcstat.st_nlink = dc_order(filestat.st_nlink);
+  dcstat.st_uid = dc_order(filestat.st_uid);
+  dcstat.st_gid = dc_order(filestat.st_gid);
+  dcstat.st_rdev = dc_order(filestat.st_rdev);
+  dcstat.st_size = dc_order(filestat.st_size);
 #ifndef __MINGW32__
-    dcstat.st_blksize = dc_order(filestat.st_blksize);
-    dcstat.st_blocks = dc_order(filestat.st_blocks);
+  dcstat.st_blksize = dc_order(filestat.st_blksize);
+  dcstat.st_blocks = dc_order(filestat.st_blocks);
 #endif
-    dcstat.st_atime_priv = dc_order(filestat.st_atime);
-    dcstat.st_mtime_priv = dc_order(filestat.st_mtime);
-    dcstat.st_ctime_priv = dc_order(filestat.st_ctime);
+  dcstat.st_atime_priv = dc_order(filestat.st_atime);
+  dcstat.st_mtime_priv = dc_order(filestat.st_mtime);
+  dcstat.st_ctime_priv = dc_order(filestat.st_ctime);
 
-    send_data((unsigned char *)&dcstat, ntohl(command->value0), ntohl(command->value1));
+  send_data((unsigned char *)&dcstat, ntohl(command->value0),
+            ntohl(command->value1));
 
-    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-    return 0;
+  return 0;
 }
 
-int dc_utime(unsigned char * buffer)
-{
-    struct utimbuf tbuf;
-    int retval;
-    command_3int_string_t *command = (command_3int_string_t *)buffer;
+int dc_utime(unsigned char *buffer) {
+  struct utimbuf tbuf;
+  int retval;
+  command_3int_string_t *command = (command_3int_string_t *)buffer;
 
-    if (ntohl(command->value0)) {
-	tbuf.actime = ntohl(command->value1);
-	tbuf.modtime = ntohl(command->value2);
+  if (ntohl(command->value0)) {
+    tbuf.actime = ntohl(command->value1);
+    tbuf.modtime = ntohl(command->value2);
 
-	retval = utime(map_path(command->string), &tbuf);
-    } else {
-	retval = utime(map_path(command->string), 0);
-    }
-    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+    retval = utime(map_path(command->string), &tbuf);
+  } else {
+    retval = utime(map_path(command->string), 0);
+  }
+  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-    return 0;
+  return 0;
 }
 
-int dc_opendir(unsigned char * buffer)
-{
-    DIR *somedir;
-    command_string_t *command = (command_string_t *)buffer;
-    int i;
+int dc_opendir(unsigned char *buffer) {
+  DIR *somedir;
+  command_string_t *command = (command_string_t *)buffer;
+  int i;
 
-    /* Find an open entry */
-    for(i = 0; i < MAX_OPEN_DIRS; ++i) {
-        if(!opendirs[i])
-            break;
-    }
+  /* Find an open entry */
+  for (i = 0; i < MAX_OPEN_DIRS; ++i) {
+    if (!opendirs[i])
+      break;
+  }
 
-    if(i < MAX_OPEN_DIRS) {
-        if(!(opendirs[i] = opendir(map_path(command->string))))
-            i = 0;
-        else
-            i += DIRENT_OFFSET;
-    }
-    else {
-        i = 0;
-    }
-
-    send_cmd(CMD_RETVAL, (unsigned int)i, (unsigned int)i, NULL, 0);
-
-    return 0;
-}
-
-int dc_closedir(unsigned char * buffer)
-{
-    int retval;
-    command_int_t *command = (command_int_t *)buffer;
-    uint32_t i = ntohl(command->value0);
-
-
-    if(i >= DIRENT_OFFSET && i < MAX_OPEN_DIRS + DIRENT_OFFSET) {
-        retval = closedir(opendirs[i - DIRENT_OFFSET]);
-        opendirs[i - DIRENT_OFFSET] = NULL;
-    }
-    else {
-        retval = -1;
-    }
-
-    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
-
-    return 0;
-}
-
-int dc_readdir(unsigned char * buffer)
-{
-    struct dirent *somedirent;
-    dcload_dirent_t dcdirent;
-    command_3int_t *command = (command_3int_t *)buffer;
-    uint32_t i = ntohl(command->value0);
-
-    if(i >= DIRENT_OFFSET && i < MAX_OPEN_DIRS + DIRENT_OFFSET)
-        somedirent = readdir(opendirs[i - DIRENT_OFFSET]);
+  if (i < MAX_OPEN_DIRS) {
+    if (!(opendirs[i] = opendir(map_path(command->string))))
+      i = 0;
     else
-        somedirent = NULL;
+      i += DIRENT_OFFSET;
+  } else {
+    i = 0;
+  }
 
-    if (somedirent) {
-#if defined (__APPLE__) || defined (__NetBSD__) || defined (__FreeBSD__) || defined (__OpenBSD__)
-	dcdirent.d_ino = dc_order(somedirent->d_fileno);
-	dcdirent.d_off = dc_order(0);
-	dcdirent.d_reclen = dc_order(somedirent->d_reclen);
-	dcdirent.d_type = dc_order(somedirent->d_type);
+  send_cmd(CMD_RETVAL, (unsigned int)i, (unsigned int)i, NULL, 0);
+
+  return 0;
+}
+
+int dc_closedir(unsigned char *buffer) {
+  int retval;
+  command_int_t *command = (command_int_t *)buffer;
+  uint32_t i = ntohl(command->value0);
+
+  if (i >= DIRENT_OFFSET && i < MAX_OPEN_DIRS + DIRENT_OFFSET) {
+    retval = closedir(opendirs[i - DIRENT_OFFSET]);
+    opendirs[i - DIRENT_OFFSET] = NULL;
+  } else {
+    retval = -1;
+  }
+
+  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
+
+  return 0;
+}
+
+int dc_readdir(unsigned char *buffer) {
+  struct dirent *somedirent;
+  dcload_dirent_t dcdirent;
+  command_3int_t *command = (command_3int_t *)buffer;
+  uint32_t i = ntohl(command->value0);
+
+  if (i >= DIRENT_OFFSET && i < MAX_OPEN_DIRS + DIRENT_OFFSET)
+    somedirent = readdir(opendirs[i - DIRENT_OFFSET]);
+  else
+    somedirent = NULL;
+
+  if (somedirent) {
+#if defined(__APPLE__) || defined(__NetBSD__) || defined(__FreeBSD__) ||       \
+    defined(__OpenBSD__)
+    dcdirent.d_ino = dc_order(somedirent->d_fileno);
+    dcdirent.d_off = dc_order(0);
+    dcdirent.d_reclen = dc_order(somedirent->d_reclen);
+    dcdirent.d_type = dc_order(somedirent->d_type);
 #else
-	dcdirent.d_ino = dc_order(somedirent->d_ino);
-# if defined(_WIN32) || defined(__CYGWIN__)
-	dcdirent.d_off = dc_order(0);
-	dcdirent.d_reclen = dc_order(0);
-	dcdirent.d_type = dc_order(0);
-# else
-	dcdirent.d_off = dc_order(somedirent->d_off);
-	dcdirent.d_reclen = dc_order(somedirent->d_reclen);
-	dcdirent.d_type = dc_order(somedirent->d_type);
-# endif
+    dcdirent.d_ino = dc_order(somedirent->d_ino);
+#if defined(_WIN32) || defined(__CYGWIN__)
+    dcdirent.d_off = dc_order(0);
+    dcdirent.d_reclen = dc_order(0);
+    dcdirent.d_type = dc_order(0);
+#else
+    dcdirent.d_off = dc_order(somedirent->d_off);
+    dcdirent.d_reclen = dc_order(somedirent->d_reclen);
+    dcdirent.d_type = dc_order(somedirent->d_type);
 #endif
-	strcpy(dcdirent.d_name, somedirent->d_name);
+#endif
+    strcpy(dcdirent.d_name, somedirent->d_name);
 
-	send_data((unsigned char *)&dcdirent, ntohl(command->value1), ntohl(command->value2));
-	send_cmd(CMD_RETVAL, 1, 1, NULL, 0);
-	return 0;
-    }
-
-    send_cmd(CMD_RETVAL, 0, 0, NULL, 0);
-
+    send_data((unsigned char *)&dcdirent, ntohl(command->value1),
+              ntohl(command->value2));
+    send_cmd(CMD_RETVAL, 1, 1, NULL, 0);
     return 0;
+  }
+
+  send_cmd(CMD_RETVAL, 0, 0, NULL, 0);
+
+  return 0;
 }
 
-int dc_rewinddir(unsigned char * buffer)
-{
-    int retval;
-    command_int_t *command = (command_int_t *)buffer;
-    uint32_t i = ntohl(command->value0);
+int dc_rewinddir(unsigned char *buffer) {
+  int retval;
+  command_int_t *command = (command_int_t *)buffer;
+  uint32_t i = ntohl(command->value0);
 
+  if (i >= DIRENT_OFFSET && i < MAX_OPEN_DIRS + DIRENT_OFFSET) {
+    rewinddir(opendirs[i - DIRENT_OFFSET]);
+    opendirs[i - DIRENT_OFFSET] = NULL;
+    retval = 0;
+  } else {
+    retval = -1;
+  }
 
-    if(i >= DIRENT_OFFSET && i < MAX_OPEN_DIRS + DIRENT_OFFSET) {
-        rewinddir(opendirs[i - DIRENT_OFFSET]);
-        opendirs[i - DIRENT_OFFSET] = NULL;
-        retval = 0;
-    }
-    else {
-        retval = -1;
-    }
+  send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
 
-    send_cmd(CMD_RETVAL, retval, retval, NULL, 0);
-
-    return 0;
+  return 0;
 }
 
-int dc_cdfs_redir_read_sectors(int isofd, unsigned char * buffer)
-{
-    int start;
-    unsigned char * buf;
-    command_3int_t *command = (command_3int_t *)buffer;
+int dc_cdfs_redir_read_sectors(int isofd, unsigned char *buffer) {
+  int start;
+  unsigned char *buf;
+  command_3int_t *command = (command_3int_t *)buffer;
 
-    start = ntohl(command->value0) - 150;
+  start = ntohl(command->value0) - 150;
 
-    lseek(isofd, start * 2048, SEEK_SET);
+  lseek(isofd, start * 2048, SEEK_SET);
 
-    buf = malloc(ntohl(command->value2));
+  buf = malloc(ntohl(command->value2));
 
-    read(isofd, buf, ntohl(command->value2));
+  read(isofd, buf, ntohl(command->value2));
 
-    send_data(buf, ntohl(command->value1), ntohl(command->value2));
+  send_data(buf, ntohl(command->value1), ntohl(command->value2));
 
-    send_cmd(CMD_RETVAL, 0, 0, NULL, 0);
+  send_cmd(CMD_RETVAL, 0, 0, NULL, 0);
 
-    free(buf);
-    return 0;
+  free(buf);
+  return 0;
 }
 
 #define GDBBUFSIZE 1024
@@ -526,59 +507,59 @@ extern int gdb_server_socket;
 extern int socket_fd;
 #endif
 
-int dc_gdbpacket(unsigned char * buffer)
-{
-    size_t in_size, out_size;
-    static char gdb_buf[GDBBUFSIZE];
-    int retval = 0;
+int dc_gdbpacket(unsigned char *buffer) {
+  size_t in_size, out_size;
+  static char gdb_buf[GDBBUFSIZE];
+  int retval = 0;
 
 #ifdef __MINGW32__
-	if (gdb_server_socket == INVALID_SOCKET) {
+  if (gdb_server_socket == INVALID_SOCKET) {
 #else
-	if (gdb_server_socket < 0) {
+  if (gdb_server_socket < 0) {
 #endif
-        send_cmd(CMD_RETVAL, -1, -1, NULL, 0);
-    }
+    send_cmd(CMD_RETVAL, -1, -1, NULL, 0);
+  }
 
-    if (socket_fd == 0) {
-	printf( "waiting for gdb client connection...\n" );
-	socket_fd = accept( gdb_server_socket, NULL, NULL );
+  if (socket_fd == 0) {
+    printf("waiting for gdb client connection...\n");
+    socket_fd = accept(gdb_server_socket, NULL, NULL);
 #ifdef __MINGW32__
-	if ( socket_fd != INVALID_SOCKET)
+    if (socket_fd != INVALID_SOCKET)
 #endif
-	if ( socket_fd == 0) {
-	    log_error("error accepting gdb server connection");
-	    return -1;
-	}
-    }
-
-    command_2int_string_t *command = (command_2int_string_t *)buffer;
-    /* value0 = in_size, value1 = out_size, string = packet */
-
-    in_size = ntohl(command->value0);
-    out_size = ntohl(command->value1);
-
-    if (in_size)
-	send(socket_fd, command->string, in_size, 0);
-
-    if (out_size) {
-	retval = recv(socket_fd, gdb_buf, out_size > GDBBUFSIZE ? GDBBUFSIZE : out_size, 0);
-
-	if (retval == 0)
-	socket_fd = -1;
-    }
-#ifdef __MINGW32__
-	if(retval == SOCKET_ERROR) {
-	fprintf(stderr, "Got socket error: %d\n", WSAGetLastError());
-	return -1;
-	}
-#else
-    if(retval == -1) {
-        fprintf(stderr, "Got socket error: %s\n", strerror(errno));
+      if (socket_fd == 0) {
+        log_error("error accepting gdb server connection");
         return -1;
-    }
-#endif
-    send_cmd(CMD_RETVAL, retval, retval, (unsigned char *)gdb_buf, retval);
+      }
+  }
 
-    return 0;
+  command_2int_string_t *command = (command_2int_string_t *)buffer;
+  /* value0 = in_size, value1 = out_size, string = packet */
+
+  in_size = ntohl(command->value0);
+  out_size = ntohl(command->value1);
+
+  if (in_size)
+    send(socket_fd, command->string, in_size, 0);
+
+  if (out_size) {
+    retval = recv(socket_fd, gdb_buf,
+                  out_size > GDBBUFSIZE ? GDBBUFSIZE : out_size, 0);
+
+    if (retval == 0)
+      socket_fd = -1;
+  }
+#ifdef __MINGW32__
+  if (retval == SOCKET_ERROR) {
+    fprintf(stderr, "Got socket error: %d\n", WSAGetLastError());
+    return -1;
+  }
+#else
+  if (retval == -1) {
+    fprintf(stderr, "Got socket error: %s\n", strerror(errno));
+    return -1;
+  }
+#endif
+  send_cmd(CMD_RETVAL, retval, retval, (unsigned char *)gdb_buf, retval);
+
+  return 0;
 }

--- a/host-src/tool/syscalls.h
+++ b/host-src/tool/syscalls.h
@@ -22,7 +22,9 @@
 #ifndef __SYSCALLS_H__
 #define __SYSCALLS_H__
 
-int dc_fstat(unsigned char * buffer);
+void set_mappath(char *path);
+
+int dc_fstat(unsigned char *buffer);
 int dc_write(unsigned char * buffer);
 int dc_read(unsigned char * buffer);
 int dc_open(unsigned char * buffer);

--- a/make-cdi/Makefile
+++ b/make-cdi/Makefile
@@ -1,0 +1,24 @@
+CDRECORD	= wodim dev=0,0,0 speed=8
+DD		= dd
+CP		= cp
+MKISOFS		= genisoimage
+CAT		= cat
+TOUCH		= touch
+1ST_READ	= ../target-src/1st_read/1st_read.bin
+
+dctoolip: 1st_read.bin
+	/opt/toolchains/dc/bin/mkdcdisc -n $@ -e $< -N -o $@.cdi -v 3 -m -d romdisk
+
+
+1st_read.bin: $(1ST_READ)
+	$(CP) $(1ST_READ) 1st_read.bin
+
+
+$(1ST_READ):
+	cd ../target-src && make
+
+
+.PHONY : clean
+clean:
+	rm -f dctoolip.cdi 1st_read.bin
+


### PR DESCRIPTION
Added an -m option to dc-tool-ip as an alternative to the -c (chroot) option
The two have been made mutually exclusive with an error message indicating just that

The -m option foregoes the usage of chroot and accesses the filesystem in the given folder directly

There is a little bit of safety built in, in that the realpath function is used to ensure that paths are beneath the path given with -m 

The big advantage is that it allows easy debugging without having to wreck your IDE settings with root ownership (a problem I've been having in VSCode).

Another possible advantage is that the -m option should also work in MINGW, although I haven't tested this myself yet. 