### PR TITLE
Added "fast mode" for much faster transfer speeds.

### DIFF
--- a/Makefile.cfg
+++ b/Makefile.cfg
@@ -24,7 +24,7 @@ endif
 
 ifdef USING_KOS_GCC
   # Use these for Sega Dreamcast toolchain built using dc-chain (KallistiOS)
-  TARGETPREFIX	= /opt/toolchains/dc/sh-elf
+  TARGETPREFIX	= $(KOS_CC_BASE)
   BINTARGETPREFIX = $(TARGETPREFIX)
 else
   # This is for portable sh4-elf-gcc GCC 9.2.0
@@ -99,7 +99,7 @@ endif
 # You generally shouldn't change this unless you are making forked
 # versions (or test versions)
 # Version numbers must be of the form x.x.x
-VERSION = 2.0.2
+VERSION = 2.0.3
 
 # Define this if you want a standalone, statically linked, no dependency binary
 #STANDALONE_BINARY = 1


### PR DESCRIPTION
By using the "-f" option with dc-tool-ip, you may disable all artificial RX FIFO delays and sleeps, providing SUBSTANTIALLY faster transfer speeds, at the cost of potentially increasing the incidence of packet loss, depending on your network load.

This configuration brought DCA3's initial load time down from TWENTY MINUTES to less than a minute when streaming assets from the BBA. It allowed jnmartin to stream Doom64 BGM in real-time at 60FPS, and it substantially improved debuggability for Bruce with NuQuake using the BBA.

Due to the fact it has been so popular and makes such a massive difference in load times, I figured it should get upstreamed. Yes, there's a higher potential for packet loss, but it still almost never happens, unless your router is overloaded... and the transfer speeds are so fast that you can easily just resend the ELF anyway.

Additionally, I have done the following:
- Bumped the patch version number up, since it appears we do that after the addition of new flags
- Changed the default toolchain prefix to use KOS's environment variables when `USING_KOS_GCC` is enabled. This fixes build issues for people like me, who have the toolchain installed in a different location. :)