### PR TITLE
Cdfs redir fixes

### DIFF
--- a/target-src/dcload/cdfs_syscalls.c
+++ b/target-src/dcload/cdfs_syscalls.c
@@ -53,7 +53,8 @@ int gdGdcReqCmd(int cmd, int *param)
 	int i;
 
 	switch (cmd) {
-	case 16: /* read sectors */
+	case 16: /* read sectors PIO */
+    case 17: /* read sectors DMA */
 
 		memcpy(command->id, CMD_CDFSREAD, 4);
 		command->value0 = htonl(param[0]);

--- a/target-src/dcload/cdfs_syscalls.c
+++ b/target-src/dcload/cdfs_syscalls.c
@@ -35,6 +35,17 @@ struct TOC {
 	unsigned int dunno;
 };
 
+/* gdGdcReqCmd must return a GD request id that is >= 1 on success, 0
+   for failure, matching the real GD-ROM BIOS. */
+static unsigned short gd_next_request_id = 1;
+
+static int gd_next_req_id(void) {
+    if(++gd_next_request_id == 0)
+        gd_next_request_id = 1;
+
+    return (int)gd_next_request_id;
+}
+
 int gdGdcReqCmd(int cmd, int *param)
 {
 	command_3int_t * command = (command_3int_t *)(pkt_buf + ETHER_H_LEN + IP_H_LEN + UDP_H_LEN);
@@ -54,7 +65,7 @@ int gdGdcReqCmd(int cmd, int *param)
 		param[3] = 0;
 		gdStatus = 2;
 
-		return 0;
+		return gd_next_req_id();
 		break;
 	case 19: /* read toc */
 		toc = (struct TOC *)param[1];
@@ -64,15 +75,15 @@ int gdGdcReqCmd(int cmd, int *param)
 		toc->first = 0x41010000; /* first = track 1 */
 		toc->last = 0x41010000; /* last = track 1 */
 		gdStatus = 2;
-		return 0;
+		return gd_next_req_id();
 		break;
 	case 24: /* init disc */
 		gdStatus = 2;
-		return 0;
+		return gd_next_req_id();
 		break;
 	default:
 		gdStatus = 0;
-		return -1;
+		return 0;
 		break;
 	}
 


### PR DESCRIPTION
CDFS redirection hasn't worked right since a lot of the updates to the core KOS driver in early 2024, and was entirely broken since the switch to DMA transfers as default in https://github.com/KallistiOS/KallistiOS/pull/659

This generally matches the fixes as implemented here: https://github.com/andressbarajas/kos-tool/commit/71856a12b98b409669b50ce25f434fb0e173a240 and following the discord discussion here: https://discord.com/channels/488332893324836864/488332893324836866/1523760146772398321