### PR TITLE
BBA Compat update

### DIFF
--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -51,11 +51,6 @@ static void rtl_init(void);
 static void pktcpy(unsigned char *dest, unsigned char *src, unsigned int n);
 static int rtl_bb_rx(void);
 
-// 8, 16, and 32 bit access to G2 addresses
-static vuc * const g28 = REGC(0xa1000000);
-static vus * const g216 = REGS(0xa1000000);
-static vul * const g232 = REGL(0xa1000000);
-
 #define g2_write_8(address, value) *((volatile uint8_t *)(address)) = (value)
 #define g2_write_16(address, value) *((volatile uint16_t *)(address)) = (value)
 #define g2_write_32(address, value) *((volatile uint32_t *)(address)) = (value)
@@ -508,7 +503,7 @@ int rtl_bb_tx(unsigned char * pkt, int len) // pg. 15 in RTL8139C datasheet: htt
 	__builtin_prefetch(copyback_pkt_base);
 
 	// Set GAPS DMA image offset pointer to relevant TX region
-	g232[0x142c/4] = (unsigned int)txdesc[rtl.cur_tx];
+	g2_write_32(GAPS_BASE + 0x142c, (unsigned int)txdesc[rtl.cur_tx]);
 
 	/* 8139 doesn't auto-pad */
 	if(len < 60) // This condition may look a little gnarly, but that's because it's meant for speed above all else.
@@ -643,8 +638,8 @@ static void pktcpy(unsigned char *dest, unsigned char *src, unsigned int n) // d
 	while((*(volatile unsigned int*)0xa05f688c) & 0x20U);
 
 	// Set GAPS DMA image offset pointer to relevant RX region
-	//--	g232[0x142c/4] = (unsigned int)src;
-	g232[0x142c/4] = (unsigned int)src - 2; // Yup, this works. So we can just use memcpy_32bit()
+	//--	g2_write_32(GAPS_BASE + 0x142c, (unsigned int)src);
+	g2_write_32(GAPS_BASE + 0x142c, (unsigned int)src - 2); // Yup, this works. So we can just use memcpy_32bit()
 
 	// NOWRAP
 	// Note: the +3 may mean we read some of the CRC for not-byte-multiple packets. That's fine: it doesn't cause us any problems.

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -56,7 +56,12 @@ static vuc * const g28 = REGC(0xa1000000);
 static vus * const g216 = REGS(0xa1000000);
 static vul * const g232 = REGL(0xa1000000);
 
+#define g2_write_8(address, value) *((volatile uint8_t *)(address)) = (value)
+#define g2_write_16(address, value) *((volatile uint16_t *)(address)) = (value)
 #define g2_write_32(address, value) *((volatile uint32_t *)(address)) = (value)
+#define g2_read_8(address) *((volatile uint8_t *)(address))
+#define g2_read_16(address) *((volatile uint16_t *)(address))
+#define g2_read_32(address) *((volatile uint32_t *)(address))
 
 /* 8, 16, and 32 bit access to the PCI I/O space (configured by GAPS) */
 static vuc * const nic8 = REGC(0xa1001700);
@@ -77,6 +82,8 @@ static vuc * const txdesc[4] = {
 	REGC(GAPS_TX_IO_AREA + 0x7000),
 	REGC(GAPS_TX_IO_AREA + 0x7800)
 };
+
+#define RTL_MEM                 (0x1840000)
 
 /* GAPS PCI stuff probably ought to be moved to another file... */
 #define GAPS_BASE 0xa1000000
@@ -383,25 +390,27 @@ int rtl_bb_init(void)
 	// The BBA uses the range 0x01840000-0x0184ffff for TX and RX (with usage above
 	// 0x01848000 apparently for GAPS DMA), plus the 2 bytes at 0x0183fffc for... something
 
-	/* Initialize the "GAPS" PCI glue controller. */
-
+    /* Initialize the "GAPS" PCI glue controller. */
 	// NOTE: Setting 0x5a14a500 turns off GAPS.
-	g232[0x1418/4] = 0x5a14a501;                /* M */
-	i = 10000;
+    g2_write_32(GAPS_BASE + 0x1418, 0x5a14a501);    /* M */
+    i = 10000;
 	// This delay is probably the part where the RealTek 8139C datasheet says to
 	// wait 2ms for the chip to powerup and load its config from its EEPROM
-	while ((!(g232[0x1418/4] & 1)) && (i > 0))
-		i--;
-	if (!(g232[0x1418/4] & 1)) { // timed out waiting for rtl8139c to init
-		return -1;
-	}
+    while(!(g2_read_32(GAPS_BASE + 0x1418) & 1) && i > 0)
+        i--;
 
-	g232[0x1420/4] = 0x01000000;
-	g232[0x1424/4] = 0x01000000;
-	g232[0x1428/4] = 0x01840000;                /* 32k SRAM Map Base (?) */
+    /* timed out waiting for rtl8139c to init */
+    if(!(g2_read_32(GAPS_BASE + 0x1418) & 1)) {
+        return -1;
+    }
+
+    g2_write_32(GAPS_BASE + 0x1420, 0x01000000);
+    g2_write_32(GAPS_BASE + 0x1424, 0x01000000);
+    g2_write_32(GAPS_BASE + 0x1428, RTL_MEM);       /* DMA Base */
 	/* Register offset 0x142c controls where the image area at GAPS offset 0x8000 (so 0x01848000) points to, which is used by DMA */
-	g232[0x1414/4] = 0x00000001; // Interrupt-related...? (Whatever this is, it gets 1 written to it a couple times, and gets a zero written to it in the same places where 0x1418 gets the turn-off code...)
-	g232[0x1434/4] = 0x00000001;
+    g2_write_32(GAPS_BASE + 0x1414, 0x00000001); // Interrupt-related...? (Whatever this is, it gets 1 written to it a couple times, and gets a zero written to it in the same places where 0x1418 gets the turn-off code...)
+    g2_write_32(GAPS_BASE + 0x1434, 0x00000001);
+
 	// There appears to be a register at offset 0x1410, which has 0x0c003000 in it. This appears to be a pretty random address in the syscall area.
 	// It doesn't seem to be used for anything, though, and it just seems to get read from in its unused function--it's never written to.
 	// Similarly, 0x1430 has 0x00000010 in it, who knows what for. This one doesn't even have an unused function for it.
@@ -414,60 +423,52 @@ int rtl_bb_init(void)
 	// It has a custom ven:dev ID, but the class ID in 0x1608 indicates a network controller (byte 0x160b = 0x02 = network controller, 0x160a = 0x00 = Ethernet controller)
 	// See PCI Local Bus Specification 2.2 (2.3 has all the 2.2 stuff in it and the RTL8139C uses 2.2)
 	// This is also documented in the RTL8139C's datasheet, under "PCI Configuration Space Registers"
-	g216[0x1606/2] = 0xf900; // PCI Status Register
-	g232[0x1630/4] = 0x00000000; // PCI BMAR
-	g28[0x163c] = 0x00; // Interrupt Line
-	g28[0x160d] = 0xf0; // Primary Latency Timer
-	g216[0x1604/2] |= 0x6; // PCI Command Register (note: Fast Back-to-Back is read-only 0 on this bridge)
-	// 0x1610 (BAR0, I/O BAR) reads back as 0x00000001, which is I/O Space Indicator
-	g232[0x1614/4] = 0x01000000; // BAR1 (Memory BAR)
-	// There are two extra regs here, though, that are GAPS-specific (0x1650 and 0x1654).
-	if(g28[0x1650] & 1) // ???
-	{
-		g216[0x1654/2] = (g216[0x1654/2] & 0xfffc) | 0x8000;
-	}
+    g2_write_16(GAPS_BASE + 0x1606, 0xf900);     /* PCI Status Register */
+    g2_write_32(GAPS_BASE + 0x1630, 0x00000000); /* PCI BMAR */
+    g2_write_8(GAPS_BASE + 0x163c, 0x00);        /* Interrupt Line */
+    g2_write_8(GAPS_BASE + 0x160d, 0xf0);        /* Primary Latency Timer */
 
-	// Apparently we do this again
-	g232[0x1414/4] = 0x00000001;
+    /* PCI Command Register (Fast Back-to-Back is read-only 0 on this bridge)
+       0x1610 (BAR0, I/O BAR) reads back as 0x00000001, which is I/O Space Indicator
+    */
+    g2_write_16(GAPS_BASE + 0x1604, g2_read_16(GAPS_BASE + 0x1604) | 0x6);
 
-	// Clear the GAPS area
-	memset_zeroes_64bit((void*)0x01840000, 32768/8);
-	CacheBlockPurge((void*)0x01840000, 32768/32); // Write back and invalidate the cache over that area since it's volatile
+    g2_write_32(GAPS_BASE + 0x1614, 0x01000000); /* BAR1 (Memory BAR) */
 
-	// do this weird dance
-	// Appears to set and check some magic numbers to know if it's being initted properly...?
-	if(g232[0x141c/4] == 0x41474553) // Hah, this is ASCII for 'SEGA' in little-endian
-	{
-		g232[0x141c/4] = 0x55aaff00;
+    /* There are two extra regs here that are GAPS-specific (0x1650 and 0x1654). */
+    if(g2_read_8(GAPS_BASE + 0x1650) & 0x1)
+    {
+        g2_write_16(GAPS_BASE + 0x1654, (g2_read_16(GAPS_BASE + 0x1654) & 0xfffc) | 0x8000);
+    }
 
-		if(g232[0x141c/4] == 0x55aaff00)
-		{
-			g232[0x141c/4] = 0xaa5500ff;
+    /* Apparently we do this again */
+    g2_write_32(GAPS_BASE + 0x1414, 0x00000001); /* Interrupt enable */
 
-			if(g232[0x141c/4] == 0xaa5500ff)
-			{
-				g232[0x141c/4] = 0x41474553;
-				// I think GAPS automatically pulls RSTB low for 120ns, which causes the
-				// EEPROM to autoload all the registers initially. So we don't need to
-				// worry about it.
-				rtl_init();
-			}
-			else
-			{
-				return -3;
-			}
-		}
-		else
-		{
-			return -2;
-		}
-	}
-	else
-	{
-		return -1;
-	}
+    /* Clear GAPS mem */
+	memset_zeroes_64bit((void*)RTL_MEM, 32768/8);
+	CacheBlockPurge((void*)RTL_MEM, 32768/32); // Write back and invalidate the cache over that area since it's volatile
 
-	return 0;
+    /* Another magic number sequence, possibly checking previous init. */
+    /* ASCII for 'SEGA' in little-endian */
+    if(g2_read_32(GAPS_BASE + 0x141c) == 0x41474553) {
+        g2_write_32(GAPS_BASE + 0x141c, 0x55aaff00);
+
+        if(g2_read_32(GAPS_BASE + 0x141c) == 0x55aaff00) {
+            g2_write_32(GAPS_BASE + 0x141c, 0xaa5500ff);
+
+            if(g2_read_32(GAPS_BASE + 0x141c) == 0xaa5500ff) {
+                g2_write_32(GAPS_BASE + 0x141c, 0x41474553);
+                /* I think GAPS automatically pulls RSTB low for 120ns, which
+                   causes the EEPROM to autoload all the registers initially.
+                   So we don't need to worry about it.
+                */
+                rtl_init();
+                return 0;
+            }
+        }
+    }
+
+    return -3;
 }
 
 void rtl_bb_start(void)

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -85,7 +85,6 @@ static int rtl_bb_rx(void);
 #define NIC(ADDR) (GAPS_BASE + 0x1700 + (ADDR))
 
 /* 8, 16, and 32 bit access to the PCI I/O space (configured by GAPS) */
-static vus *const nic16 = REGS(NIC(0));
 static vul *const nic32 = REGL(NIC(0));
 
 /* 8, 16, and 32 bit access to the PCI MEMMAP space (configured by GAPS) */
@@ -274,7 +273,8 @@ static void rtl_init(void) {
         : // clobbers
         );
 
-        nic16[RT_INTRMASK/2] = 0x53; // Enable specific interrupts
+        // Enable specific interrupts
+        g2_write_16(NIC(RT_INTRMASK), RT_INT_RXFIFO_OVERFLOW | RT_INT_RXBUF_OVERFLOW | RT_INT_RX_ERR | RT_INT_RX_OK);
 
         asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
 
@@ -325,7 +325,8 @@ static void rtl_init(void) {
 
         asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
 
-        nic16[RT_INTRMASK/2] = 0; // Disable interrupts because we don't want them
+        // Disable interrupts because we don't want them
+        g2_write_16(NIC(RT_INTRMASK), 0);
         // Restore SR
         asm volatile ("ldc %[in], SR\n"
         : // outputs
@@ -742,7 +743,7 @@ static int rtl_bb_rx() {
         if(rtl.cur_rx >= RX_BUFFER_LEN) {
             // Prevent underflowing the RX buffer
             rtl.cur_rx %= RX_BUFFER_LEN;
-            nic16[RT_RXBUFTAIL/2] = 0x7ff0;
+            g2_write_16(NIC(RT_RXBUFTAIL), 0x7ff0);
             // According to the RTL8139C datasheet, 0xfff0 = 65520 is the default value of the register,
             // and the register cannot be written to before data has been read from the buffer for some
             // reason. So, presumably, we can just use that value here.
@@ -755,7 +756,7 @@ static int rtl_bb_rx() {
         }
         else {
             rtl.cur_rx %= RX_BUFFER_LEN;
-            nic16[RT_RXBUFTAIL/2] = rtl.cur_rx - 16;
+            g2_write_16(NIC(RT_RXBUFTAIL), rtl.cur_rx - 16);
             // Why 16? NetBSD and Linux do this, too. Status is 4, CRC appended is 4, what's the other 8?
             // Things don't work if this isn't 16, anyways (I tried changing it). Maybe this is 16 for DMA reasons?
             // RealTek does it here: https://www.cs.usfca.edu/~cruse/cs326f04/RTL8139_ProgrammersGuide.pdf
@@ -827,10 +828,11 @@ void rtl_bb_loop(int is_main_loop) {
                 disp_status("link change...");
             }
 
-            nic16[RT_MII_BMCR/2] = 0x9200;
+            /* Reset, Enable, and start auto-negotiation */
+            g2_write_16(NIC(RT_MII_BMCR), RT_MII_RESET | RT_MII_AN_ENABLE | RT_MII_AN_START);
 
             /* wait for valid link */
-            while(!(nic16[RT_MII_BMSR/2] & 0x20));
+            while(!(g2_read_16(NIC(RT_MII_BMSR)) & RT_MII_AN_COMPLETE));
 
             /* wait for the additional link change interrupt that is coming */
             while(!(g2_read_16(NIC(RT_INTRSTATUS)) & RT_INT_RXFIFO_UNDERRUN));
@@ -862,8 +864,8 @@ void rtl_bb_loop(int is_main_loop) {
         if(intr & RT_INT_RXBUF_OVERFLOW) {
 /*
             // Update CAPR
-            rtl.cur_rx = nic16[RT_RXBUFHEAD];
-            nic16[RT_RXBUFTAIL] = rtl.cur_rx - 16;
+            rtl.cur_rx = g2_read_16(NIC(RT_RXBUFHEAD));
+            g2_write_16(NIC(RT_RXBUFTAIL), rtl.cur_rx - 16);
             rtl.cur_rx = 0;
 
             // Disable receive

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -29,7 +29,6 @@ static char uint_string_array[11] = {0};
 #endif
 // end TEMP
 
-static rtl_status_t rtl = {0};
 static volatile unsigned char rtl_link_up = 0;
 static volatile unsigned char rtl_is_copying = 0;
 
@@ -75,7 +74,7 @@ static void rtl_init(void);
 static int gaps_detect(void) {
     // This pointer's data is always aligned to 4 bytes--just look at the register address!
     const char *str = (char *)REGC(0xa1001400);
-    if(!memcmp_32bit_eq(str, GAPSPCI_ID, 16/4)) {
+    if(!memcmp_32bit_eq(str, "GAPSPCI_BRIDGE_2", 16/4)) {
         global_bg_color = BBA_BG_COLOR;
         installed_adapter = BBA_MODEL;
 
@@ -124,12 +123,21 @@ static int gaps_init(void) {
 
     // Now configure the RTL8139's PCI configuration
 
-    // VEN:DEV is 11db:1234 (vendor code is "Sega Enterprises, LTD")
-    // The GAPS bridge is really just an MMU with a memory buffer that maps the RTL8139C to the Dreamcast's memory space,
-    // so these are actually the PCI configuration registers for the RTL8139, not GAPS (those are just the 0x1400 regs).
-    // It has a custom ven:dev ID, but the class ID in 0x1608 indicates a network controller (byte 0x160b = 0x02 = network controller, 0x160a = 0x00 = Ethernet controller)
-    // See PCI Local Bus Specification 2.2 (2.3 has all the 2.2 stuff in it and the RTL8139C uses 2.2)
-    // This is also documented in the RTL8139C's datasheet, under "PCI Configuration Space Registers"
+    /* VEN:DEV is 11db:1234 (vendor code is "Sega Enterprises, LTD")
+       The GAPS bridge is really just an MMU with a memory buffer that maps
+       the RTL8139C to the Dreamcast's memory space, so these are actually
+       the PCI configuration registers for the RTL8139, not GAPS (those are
+       just the 0x1400 regs).
+
+       It has a custom ven:dev ID, but the class ID in 0x1608 indicates a
+       network controller (byte 0x160b = 0x02 = network controller,
+       0x160a = 0x00 = Ethernet controller)
+
+       See PCI Local Bus Specification 2.2 (2.3 has all the 2.2 stuff in
+       it and the RTL8139C uses 2.2). This is also documented in the
+       RTL8139C's datasheet, under "PCI Configuration Space Registers"
+    */
+
     g2_write_16(GAPS_BASE + 0x1606, 0xf900);     /* PCI Status Register */
     g2_write_32(GAPS_BASE + 0x1630, 0x00000000); /* PCI BMAR */
     g2_write_8(GAPS_BASE + 0x163c, 0x00);        /* Interrupt Line */
@@ -177,11 +185,20 @@ static int gaps_init(void) {
     return -3;
 }
 
+/****************************************************************************/
+/* RTL8193C stuff */
+
+/* RTL8139C Config/Status info */
+struct {
+	unsigned short cur_rx;                /* Current Rx read ptr */
+	unsigned short cur_tx;                /* Current available Tx slot */
+	unsigned char  mac[6];                /* Mac address */
+} rtl = {0};
 
 /* 8, 16, and 32 bit access to the PCI I/O space (configured by GAPS) */
 #define NIC(ADDR) (GAPS_BASE + 0x1700 + (ADDR))
 
-/* 8, 16, and 32 bit access to the PCI MEMMAP space (configured by GAPS) */
+/* 8 and 32 bit access to the PCI MEMMAP space (configured by GAPS) */
 static uint32_t const rtl_mem = MEM_AREA_P2_BASE + RTL_MEM;
 
 #define GAPS_RX_IO_AREA (RTL_MEM | MEM_AREA_P1_BASE)

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -490,12 +490,12 @@ int rtl_bb_init(void)
 
 void rtl_bb_start(void)
 {
-	nic32[RT_RXCONFIG/4] |= 0x0000000a;
+	g2_write_32(NIC(RT_RXCONFIG), g2_read_32(NIC(RT_RXCONFIG)) | (RT_RXC_APM | RT_RXC_AB));
 }
 
 void rtl_bb_stop(void)
 {
-	nic32[RT_RXCONFIG/4] &= 0xfffffff5;
+    g2_write_32(NIC(RT_RXCONFIG), g2_read_32(NIC(RT_RXCONFIG)) & ~(RT_RXC_APM | RT_RXC_AB));
 }
 
 int rtl_bb_tx(unsigned char * pkt, int len) // pg. 15 in RTL8139C datasheet: http://realtek.info/pdf/rtl8139cp.pdf
@@ -783,9 +783,10 @@ static int rtl_bb_rx()
 		}
 
 		// Ack it
-		unsigned short i = nic16[RT_INTRSTATUS/2];
-		if (i & RT_INT_RX_ACK)
-			nic16[RT_INTRSTATUS/2] = RT_INT_RX_ACK;
+        unsigned short intr = g2_read_16(NIC(RT_INTRSTATUS));
+
+        if(intr & RT_INT_RX_ACK)
+            g2_write_16(NIC(RT_INTRSTATUS), RT_INT_RX_ACK);
 
 		processed++;
 
@@ -830,10 +831,10 @@ void rtl_bb_loop(int is_main_loop)
 	{
 
 		/* Check interrupt status */
-		if (nic16[RT_INTRSTATUS/2] != intr)
+		if (g2_read_16(NIC(RT_INTRSTATUS)) != intr)
 		{
-			intr = nic16[RT_INTRSTATUS/2];
-			nic16[RT_INTRSTATUS/2] = intr & ~RT_INT_RX_ACK;
+			intr = g2_read_16(NIC(RT_INTRSTATUS));
+            g2_write_16(NIC(RT_INTRSTATUS), intr & ~RT_INT_RX_ACK);
 		}
 
 		/* Did we receive some data? */
@@ -858,8 +859,8 @@ void rtl_bb_loop(int is_main_loop)
 			while (!(nic16[RT_MII_BMSR/2] & 0x20));
 
 			/* wait for the additional link change interrupt that is coming */
-			while (!(nic16[RT_INTRSTATUS/2] & RT_INT_RXFIFO_UNDERRUN));
-			nic16[RT_INTRSTATUS/2] = RT_INT_RXFIFO_UNDERRUN;
+			while (!(g2_read_16(NIC(RT_INTRSTATUS)) & RT_INT_RXFIFO_UNDERRUN));
+            g2_write_16(NIC(RT_INTRSTATUS), RT_INT_RXFIFO_UNDERRUN);
 
 			if (booted && (!running))
 			{
@@ -883,7 +884,7 @@ void rtl_bb_loop(int is_main_loop)
 		{
 			/* must clear Rx Buffer Overflow too for some reason */
 			// It's an errata (hardware bug/quirk), this needs to be done.
-			nic16[RT_INTRSTATUS/2] = RT_INT_RXBUF_OVERFLOW;
+			g2_write_16(NIC(RT_INTRSTATUS), RT_INT_RXBUF_OVERFLOW);
 		}
 
 		/* Rx Buffer overflow */
@@ -906,7 +907,7 @@ void rtl_bb_loop(int is_main_loop)
 			nic32[RT_RXCONFIG/4] = 0x0000f60a; // This should be whatever is set in init plus enabling packet reception (| 0x...a)
 
 			// clear interrupts
-			nic16[RT_INTRSTATUS/2] = 0xffff;
+            g2_write_16(NIC(RT_INTRSTATUS), 0xffff);
 	*/
 			// NetBSD, FreeBSD, and OpenBSD all just do a full re-init if this happens.
 			rtl_init();

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -59,6 +59,9 @@ static int rtl_bb_rx(void);
 #define g2_read_32(address) *((volatile uint32_t *)(address))
 
 /* 8, 16, and 32 bit access to the PCI I/O space (configured by GAPS) */
+#define NIC(ADDR) (GAPS_BASE + 0x1700 + (ADDR))
+
+/* 8, 16, and 32 bit access to the PCI I/O space (configured by GAPS) */
 static vuc * const nic8 = REGC(0xa1001700);
 static vus * const nic16 = REGS(0xa1001700);
 static vul * const nic32 = REGL(0xa1001700);
@@ -105,28 +108,28 @@ int gaps_detect(void) {
 
 static void rtl_reset(void)
 {
-	/* Soft-reset the chip */
-	nic8[RT_CHIPCMD] = RT_CMD_RESET;
+    /* Soft-reset the chip */
+    g2_write_8(NIC(RT_CHIPCMD), RT_CMD_RESET);
 
-	/* Wait for it to come back */
-	while (nic8[RT_CHIPCMD] & RT_CMD_RESET);
+    /* Wait for it to come back */
+    while (g2_read_8(NIC(RT_CHIPCMD)) & RT_CMD_RESET);
 }
 
 static void rtl_init(void)
 {
-	unsigned int tmp;
+    unsigned int tmp;
 
-	/* Read MAC address */
-	// Don't need to do anything with the eeprom if we're just reading it.
-	tmp = nic32[RT_IDR0];
-	rtl.mac[0] = tmp & 0xff;
-	rtl.mac[1] = (tmp >> 8) & 0xff;
-	rtl.mac[2] = (tmp >> 16) & 0xff;
-	rtl.mac[3] = (tmp >> 24) & 0xff;
-	tmp = nic32[RT_IDR0+1];
-	rtl.mac[4] = tmp & 0xff;
-	rtl.mac[5] = (tmp >> 8) & 0xff;
-	memcpy(adapter_bba.mac, rtl.mac, 6);
+    /* Read MAC address */
+    // Don't need to do anything with the eeprom if we're just reading it.
+    tmp = g2_read_32(NIC(RT_IDR0));
+    rtl.mac[0] = tmp & 0xff;
+    rtl.mac[1] = (tmp >> 8) & 0xff;
+    rtl.mac[2] = (tmp >> 16) & 0xff;
+    rtl.mac[3] = (tmp >> 24) & 0xff;
+    tmp = g2_read_32(NIC(RT_IDR0 + 4));
+    rtl.mac[4] = tmp & 0xff;
+    rtl.mac[5] = (tmp >> 8) & 0xff;
+    memcpy(adapter_bba.mac, rtl.mac, 6);
 
 	/* Soft-reset the chip to clear any garbage from power on */
 	rtl_reset();

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -85,7 +85,6 @@ static int rtl_bb_rx(void);
 #define NIC(ADDR) (GAPS_BASE + 0x1700 + (ADDR))
 
 /* 8, 16, and 32 bit access to the PCI I/O space (configured by GAPS) */
-static vuc *const nic8 = REGC(NIC(0));
 static vus *const nic16 = REGS(NIC(0));
 static vul *const nic32 = REGL(NIC(0));
 
@@ -671,7 +670,7 @@ static int rtl_bb_rx() {
     processed = 0;
 
     /* While we have frames left to process... */
-    while(!(nic8[RT_CHIPCMD] & 1)) {
+    while(!(g2_read_8(NIC(RT_CHIPCMD)) & RT_CMD_RX_BUF_EMPTY)) {
 
         /* Get frame size and status */
         // Don't need the % there for nowrap since it happens later.
@@ -868,11 +867,11 @@ void rtl_bb_loop(int is_main_loop) {
             rtl.cur_rx = 0;
 
             // Disable receive
-            nic8[RT_CHIPCMD] = RT_CMD_TX_ENABLE;
+            g2_write_8(NIC(RT_CHIPCMD), RT_CMD_TX_ENABLE);
 
             // Wait for it
-            while( !(nic8[RT_CHIPCMD] & RT_CMD_RX_ENABLE))
-                nic8[RT_CHIPCMD] = RT_CMD_TX_ENABLE | RT_CMD_RX_ENABLE; // Weirdly, keep spamming re-enable receive
+            while( !(g2_read_8(NIC(RT_CHIPCMD)) & RT_CMD_RX_ENABLE))
+                g2_write_8(NIC(RT_CHIPCMD), RT_CMD_TX_ENABLE | RT_CMD_RX_ENABLE); // Weirdly, keep spamming re-enable receive
 
             // Re-set RXCONFIG
             nic32[RT_RXCONFIG/4] = 0x0000f60a; // This should be whatever is set in init plus enabling packet reception (| 0x...a)

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -58,33 +58,47 @@ static int rtl_bb_rx(void);
 #define g2_read_16(address) *((volatile uint16_t *)(address))
 #define g2_read_32(address) *((volatile uint32_t *)(address))
 
+#define MEM_AREA_P1_BASE        (0x80000000)
+#define MEM_AREA_P2_BASE        (0xa0000000)
+
+#define RTL_MEM                 (0x01840000)
+
+#define RX_BUFFER_SHIFT         1 /* 0 : 8Kb, 1 : 16Kb, 2 : 32Kb, 3 : 64Kb */
+
+#define RX_BUFFER_LEN           (0x2000 << RX_BUFFER_SHIFT)
+
+#define TX_BUFFER_OFFSET        (RX_BUFFER_LEN + 0x2000)
+#define TX_BUFFER_LEN           (0x800)
+#define TX_NB_BUFFERS           4
+
+#define GAPS_BASE               (0x01000000 | MEM_AREA_P2_BASE)
+
 /* 8, 16, and 32 bit access to the PCI I/O space (configured by GAPS) */
 #define NIC(ADDR) (GAPS_BASE + 0x1700 + (ADDR))
 
 /* 8, 16, and 32 bit access to the PCI I/O space (configured by GAPS) */
-static vuc * const nic8 = REGC(0xa1001700);
-static vus * const nic16 = REGS(0xa1001700);
-static vul * const nic32 = REGL(0xa1001700);
+static vuc * const nic8 = REGC(NIC(0));
+static vus * const nic16 = REGS(NIC(0));
+static vul * const nic32 = REGL(NIC(0));
 
 /* 8, 16, and 32 bit access to the PCI MEMMAP space (configured by GAPS) */
-//static vuc * const mem8 = REGC(0xa1840000);
-//static vus * const mem16 = REGS(0xa1840000);
-static vul * const mem32 = REGL(0xa1840000);
+//static vuc *const mem8 = REGC(RTL_MEM | MEM_AREA_P2_BASE);
+//static vus *const mem16 = REGS(RTL_MEM | MEM_AREA_P2_BASE);
+static vul *const mem32 = REGL(RTL_MEM | MEM_AREA_P2_BASE);
 
-#define GAPS_RX_IO_AREA 0x81840000U
-#define GAPS_TX_IO_AREA 0x81840000U
+#define GAPS_RX_IO_AREA (RTL_MEM | MEM_AREA_P1_BASE)
+#define GAPS_TX_IO_AREA (RTL_MEM | MEM_AREA_P1_BASE)
 
-static vuc * const txdesc[4] = {
-	REGC(GAPS_TX_IO_AREA + 0x6000),
-	REGC(GAPS_TX_IO_AREA + 0x6800),
-	REGC(GAPS_TX_IO_AREA + 0x7000),
-	REGC(GAPS_TX_IO_AREA + 0x7800)
+/* TX buffer pointers */
+static vuc * const txdesc[TX_NB_BUFFERS] = {
+	REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 0)),
+	REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 1)),
+	REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 2)),
+	REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 3))
 };
 
-#define RTL_MEM                 (0x1840000)
+#define GAPS_DMA_AREA (GAPS_RX_IO_AREA | 0x8000)
 
-/* GAPS PCI stuff probably ought to be moved to another file... */
-#define GAPS_BASE 0xa1000000
 
 /* Detect a GAPS PCI bridge */
 int gaps_detect(void) {
@@ -134,12 +148,13 @@ static void rtl_init(void)
 	/* Soft-reset the chip to clear any garbage from power on */
 	rtl_reset();
 
-	/* Setup Rx and Tx buffers */
-	nic32[RT_RXBUF/4] = 0x01840000;
-	nic32[RT_TXADDR0/4 + 0] = 0x01846000;
-	nic32[RT_TXADDR0/4 + 1] = 0x01846800;
-	nic32[RT_TXADDR0/4 + 2] = 0x01847000;
-	nic32[RT_TXADDR0/4 + 3] = 0x01847800;
+    /* Setup RX buffer */
+    g2_write_32(NIC(RT_RXBUF), RTL_MEM);
+
+    /* Setup TX buffers */
+    for(tmp=0; tmp<TX_NB_BUFFERS; tmp++) {
+        g2_write_32(NIC(RT_TXADDR0 + (tmp*4)), RTL_MEM + (tmp* TX_BUFFER_LEN) + TX_BUFFER_OFFSET);
+    }
 
 	asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
 
@@ -605,7 +620,7 @@ int rtl_bb_tx(unsigned char * pkt, int len) // pg. 15 in RTL8139C datasheet: htt
 	}
 
 	// Copy packet over to RTL via GAPS while also accounting for dcload-ip's packet alignment offset
-	SH4_mem_to_pkt_X_movca_32((unsigned char*)0x81848000, copyback_pkt_base, len);
+	SH4_mem_to_pkt_X_movca_32((unsigned char*)GAPS_DMA_AREA, copyback_pkt_base, len);
 	// Technically this will prefetch beyond 1536 for packets between 1504 and 1514 in size, but that's not an issue.
 
 // Tx time end
@@ -648,8 +663,8 @@ static void pktcpy(unsigned char *dest, unsigned char *src, unsigned int n) // d
 	// Note: the +3 may mean we read some of the CRC for not-byte-multiple packets. That's fine: it doesn't cause us any problems.
 	//--	SH4_pkt_to_mem_X_movca_32(dest, (unsigned char*)0x01848000, n); // This takes full n now
 	//SH4_pkt_to_mem_X_movca_32_linear(dest, (unsigned char*)0x01848000, n + 2); // This takes full n now
-	memcpy_32bit(dest, (unsigned char*)0x81848000, (n + 2 + 3)/4); // Lol this is as fast as the asm functions
-	CacheBlockInvalidate((unsigned char*)0x81848000, (n + 2 + 31)/32); // Need to invalidate the src packet
+	memcpy_32bit(dest, (unsigned char*)GAPS_DMA_AREA, (n + 2 + 3)/4); // Lol this is as fast as the asm functions
+	CacheBlockInvalidate((unsigned char*)GAPS_DMA_AREA, (n + 2 + 31)/32); // Need to invalidate the src packet
 	CacheBlockWriteBack(dest, (2 + n + 31)/32);
 }
 

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -3,6 +3,7 @@
 // actually documented in here now.
 // --Moopthehedgehog
 
+#include <stdint.h>
 #include <string.h>
 #include "packet.h"
 #include "net.h"
@@ -33,7 +34,7 @@ adapter_t adapter_bba = {
 	"Broadband Adapter (HIT-0400)",
 	{ 0 },		// Mac address
 	{ 0 },		// 2-byte alignment pad
-	rtl_bb_detect,
+	gaps_detect,
 	rtl_bb_init,
 	rtl_bb_start,
 	rtl_bb_stop,
@@ -55,6 +56,8 @@ static vuc * const g28 = REGC(0xa1000000);
 static vus * const g216 = REGS(0xa1000000);
 static vul * const g232 = REGL(0xa1000000);
 
+#define g2_write_32(address, value) *((volatile uint32_t *)(address)) = (value)
+
 /* 8, 16, and 32 bit access to the PCI I/O space (configured by GAPS) */
 static vuc * const nic8 = REGC(0xa1001700);
 static vus * const nic16 = REGS(0xa1001700);
@@ -75,8 +78,11 @@ static vuc * const txdesc[4] = {
 	REGC(GAPS_TX_IO_AREA + 0x7800)
 };
 
-int rtl_bb_detect(void)
-{
+/* GAPS PCI stuff probably ought to be moved to another file... */
+#define GAPS_BASE 0xa1000000
+
+/* Detect a GAPS PCI bridge */
+int gaps_detect(void) {
 	// This pointer's data is always aligned to 4 bytes--just look at the register address!
 	const char *str = (char*)REGC(0xa1001400);
 	if (!memcmp_32bit_eq(str, GAPSPCI_ID, 16/4))
@@ -84,15 +90,15 @@ int rtl_bb_detect(void)
 		global_bg_color = BBA_BG_COLOR;
 		installed_adapter = BBA_MODEL;
 
-		g232[0x1414/4] = 0x00000000; // Set this to 0 first thing
-		g232[0x1418/4] = 0x5a14a500; // Ensure GAPS is off
+        /* Set this to 0 first thing */
+        g2_write_32(GAPS_BASE + 0x1414, 0x00000000);
+        /* Turn GAPS off */
+        g2_write_32(GAPS_BASE + 0x1418, 0x5a14a501);
 
 		return 0;
 	}
 	else
-	{
 		return -1;
-	}
 }
 
 static void rtl_reset(void)

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -694,17 +694,12 @@ static void pktcpy(unsigned char *dest, unsigned char *src, unsigned int n) {
     CacheBlockWriteBack(dest, (2 + n + 31)/32);
 }
 
-static int rtl_bb_rx(void) {
-    int processed;
-    unsigned int rx_status;
-    unsigned int rx_size, pkt_size, ring_offset;
-    unsigned char *pkt;
-
-    processed = 0;
+static void bba_rx(void) {
+    uint32_t rx_status;
+    size_t pkt_size, ring_offset;
 
     /* While we have frames left to process... */
     while(!(g2_read_8(NIC(RT_CHIPCMD)) & RT_CMD_RX_BUF_EMPTY)) {
-
         /* Get frame size and status */
         // Don't need the % there for nowrap since it happens later.
         ring_offset = rtl.cur_rx;
@@ -712,22 +707,22 @@ static int rtl_bb_rx(void) {
         // Don't want to accidentally cache an unfinished packet.
         // This also means we don't have to worry about invalidating a block holding the status byte. Nice!
         rx_status = g2_read_32(rtl_mem + ring_offset);
-        rx_size = (rx_status >> 16) & 0xffffU;
+        unsigned int rx_size = (rx_status >> 16) & 0xffff;
+        pkt_size = rx_size - 4;
 
         /* apparently this means the rtl8139 is still copying */
-        if(rx_size == 0xfff0U) {
+        if(rx_size == 0xfff0) {
             rtl_is_copying = 1; // Really don't want to run a DHCP renewal while data is in flight...
             break;
         }
         rtl_is_copying = 0;
 
-        pkt_size = rx_size - 4;
 
         // Full loop timing
         FULL_TRIP_TIMING_START
 
         if((rx_status & 1) && (pkt_size <= RX_PKT_BUF_SIZE)) {
-            pkt = (unsigned char *)(GAPS_RX_IO_AREA + 0x0000 + ring_offset + 4); // + 4 to skip the status byte (DMA)
+            unsigned char *pkt = (unsigned char *)(GAPS_RX_IO_AREA + 0x0000 + ring_offset + 4); // + 4 to skip the status byte (DMA)
 
             // Rx time
             RX_LOOP_TIMING_START
@@ -782,12 +777,10 @@ static int rtl_bb_rx(void) {
         if(intr & RT_INT_RX_ACK)
             g2_write_16(NIC(RT_INTRSTATUS), RT_INT_RX_ACK);
 
-        processed++;
 
         FULL_TRIP_TIMING_PRINT
     }
 
-    return processed;
 }
 
 static void rtl_bb_loop(int is_main_loop) {
@@ -820,8 +813,7 @@ static void rtl_bb_loop(int is_main_loop) {
 
         /* Did we receive some data? */
         if(intr & RT_INT_RX_ACK) {
-            //i = rtl_bb_rx();
-            rtl_bb_rx();
+            bba_rx();
         }
 
         /* link change */

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -29,27 +29,11 @@ static char uint_string_array[11] = {0};
 #endif
 // end TEMP
 
-// Pull together all the goodies
-adapter_t adapter_bba = {
-    "Broadband Adapter (HIT-0400)",
-    { 0 },      // Mac address
-    { 0 },      // 2-byte alignment pad
-    gaps_detect,
-    gaps_init,
-    rtl_bb_start,
-    rtl_bb_stop,
-    rtl_bb_loop,
-    rtl_bb_tx
-};
-
 static rtl_status_t rtl = {0};
 static volatile unsigned char rtl_link_up = 0;
 static volatile unsigned char rtl_is_copying = 0;
 
-static void rtl_reset(void);
 static void rtl_init(void);
-static void pktcpy(unsigned char *dest, unsigned char *src, unsigned int n);
-static int rtl_bb_rx(void);
 
 /* KOS API shim definitions */
 
@@ -88,7 +72,7 @@ static int rtl_bb_rx(void);
 #define GAPS_BASE               (0x01000000 | MEM_AREA_P2_BASE)
 
 /* Detect a GAPS PCI bridge */
-int gaps_detect(void) {
+static int gaps_detect(void) {
     // This pointer's data is always aligned to 4 bytes--just look at the register address!
     const char *str = (char *)REGC(0xa1001400);
     if(!memcmp_32bit_eq(str, GAPSPCI_ID, 16/4)) {
@@ -107,7 +91,7 @@ int gaps_detect(void) {
 }
 
 /* Initialize GAPS PCI bridge */
-int gaps_init(void) {
+static int gaps_init(void) {
     int i;
 
     // The BBA uses the range 0x01840000-0x0184ffff for TX and RX (with usage above
@@ -485,16 +469,16 @@ static void rtl_init(void) {
 }
 
 
-void rtl_bb_start(void) {
+static void rtl_bb_start(void) {
     g2_write_32(NIC(RT_RXCONFIG), g2_read_32(NIC(RT_RXCONFIG)) | (RT_RXC_APM | RT_RXC_AB));
 }
 
-void rtl_bb_stop(void) {
+static void rtl_bb_stop(void) {
     g2_write_32(NIC(RT_RXCONFIG), g2_read_32(NIC(RT_RXCONFIG)) & ~(RT_RXC_APM | RT_RXC_AB));
 }
 
 // pg. 15 in RTL8139C datasheet: http://realtek.info/pdf/rtl8139cp.pdf
-int rtl_bb_tx(unsigned char *pkt, int len) {
+static int rtl_bb_tx(unsigned char *pkt, int len) {
     // According to KOS source we gotta wait for G2 FIFO to be empty by checking
     // this bit before reading from/writing to G2. So do that here.
     while((*(volatile unsigned int *)0xa05f688c) & 0x20U);
@@ -666,7 +650,7 @@ static void pktcpy(unsigned char *dest, unsigned char *src, unsigned int n) {
     CacheBlockWriteBack(dest, (2 + n + 31)/32);
 }
 
-static int rtl_bb_rx() {
+static int rtl_bb_rx(void) {
     int processed;
     unsigned int rx_status;
     unsigned int rx_size, pkt_size, ring_offset;
@@ -791,7 +775,7 @@ static int rtl_bb_rx() {
     return processed;
 }
 
-void rtl_bb_loop(int is_main_loop) {
+static void rtl_bb_loop(int is_main_loop) {
     unsigned int intr = 0;
     unsigned int loop_start[2] = {0};
     unsigned int loop_measure[2] = {0};
@@ -915,3 +899,16 @@ void rtl_bb_loop(int is_main_loop) {
     }
     escape_loop = 0;
 }
+
+// Pull together all the goodies
+adapter_t adapter_bba = {
+    "Broadband Adapter (HIT-0400)",
+    { 0 },      // Mac address
+    { 0 },      // 2-byte alignment pad
+    gaps_detect,
+    gaps_init,
+    rtl_bb_start,
+    rtl_bb_stop,
+    rtl_bb_loop,
+    rtl_bb_tx
+};

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -84,13 +84,8 @@ static int rtl_bb_rx(void);
 /* 8, 16, and 32 bit access to the PCI I/O space (configured by GAPS) */
 #define NIC(ADDR) (GAPS_BASE + 0x1700 + (ADDR))
 
-/* 8, 16, and 32 bit access to the PCI I/O space (configured by GAPS) */
-static vul *const nic32 = REGL(NIC(0));
-
 /* 8, 16, and 32 bit access to the PCI MEMMAP space (configured by GAPS) */
-//static vuc *const mem8 = REGC(RTL_MEM | MEM_AREA_P2_BASE);
-//static vus *const mem16 = REGS(RTL_MEM | MEM_AREA_P2_BASE);
-static vul *const mem32 = REGL(RTL_MEM | MEM_AREA_P2_BASE);
+static uint32_t const rtl_mem = MEM_AREA_P2_BASE + RTL_MEM;
 
 #define GAPS_RX_IO_AREA (RTL_MEM | MEM_AREA_P1_BASE)
 #define GAPS_TX_IO_AREA (RTL_MEM | MEM_AREA_P1_BASE)
@@ -497,14 +492,15 @@ int rtl_bb_tx(unsigned char *pkt, int len) {
     // this bit before reading from/writing to G2. So do that here.
     while((*(volatile unsigned int *)0xa05f688c) & 0x20U);
 
-    while(!(nic32[RT_TXSTATUS0/4 + rtl.cur_tx] & 0x2000U)) {
+    while(!(g2_read_32(NIC(RT_TXSTATUS0 + 4 * rtl.cur_tx)) & RT_TX_HOST_OWNS)) {
         // While tx is not complete (checking OWN)
-        if(nic32[RT_TXSTATUS0/4 + rtl.cur_tx] & 0x40000000U) {
+        if(g2_read_32(NIC(RT_TXSTATUS0 + 4 * rtl.cur_tx)) & RT_TX_ABORTED) {
             // Check for abort
-            // Found another bug: (nic32[RT_TXSTATUS0/4 + rtl.cur_tx] |= 1; // <-- If abort, set descriptor size to 1)
+            // Found another bug: (g2_write_32(NIC(RT_TXSTATUS0 + 4 * rtl.cur_tx),
+            //                      g2_read_32(NIC(RT_TXSTATUS0 + 4 * rtl.cur_tx)) | 1); // <-- If abort, set descriptor size to 1)
             // |= the length to 1 doesn't do anything if the length is an odd number >= 1...
             // Should probably be RT_TXCONFIG register |= 1, which clears abort state and retransmits, see pg 21 of RTL8139C or pg 17 of RTL8139D datasheet
-            nic32[RT_TXCONFIG/4] |= 0x1;
+            g2_write_32(NIC(RT_TXCONFIG), g2_read_32(NIC(RT_TXCONFIG)) | 0x1);
         }
     }
 
@@ -631,9 +627,10 @@ int rtl_bb_tx(unsigned char *pkt, int len) {
     // Software writes don't impact the read-only bits.
     // Zeroing also sets Early FIFO TX threshold to 8 bytes.
     // Finally, writing to the status register triggers the packet send.
-    nic32[RT_TXSTATUS0/4 + rtl.cur_tx] = len | 0x20000; // Set Early TX to 64 bytes
-    //nic32[RT_TXSTATUS0/4 + rtl.cur_tx] = len | 0x10000; // Set Early TX to 32 bytes
-    //nic32[RT_TXSTATUS0/4 + rtl.cur_tx] = len;
+    /* Transmit from the current TX buffer */
+    g2_write_32(NIC(RT_TXSTATUS0 + 4 * rtl.cur_tx), len | 0x20000); // Set Early TX to 64 bytes
+    //g2_write_32(NIC(RT_TXSTATUS0 + 4 * rtl.cur_tx), len | 0x10000); // Set Early TX to 32 bytes
+    //g2_write_32(NIC(RT_TXSTATUS0 + 4 * rtl.cur_tx), len);
 
     rtl.cur_tx = (rtl.cur_tx + 1) % 4; // Move to next txdesc buffer
 
@@ -679,7 +676,7 @@ static int rtl_bb_rx() {
         // Use uncached area for this intentionally, in case of rtl_is_copying.
         // Don't want to accidentally cache an unfinished packet.
         // This also means we don't have to worry about invalidating a block holding the status byte. Nice!
-        rx_status = mem32[0x0000/4 + ring_offset/4];
+        rx_status = g2_read_32(rtl_mem + ring_offset);
         rx_size = (rx_status >> 16) & 0xffffU;
 
         /* apparently this means the rtl8139 is still copying */
@@ -876,7 +873,7 @@ void rtl_bb_loop(int is_main_loop) {
                 g2_write_8(NIC(RT_CHIPCMD), RT_CMD_TX_ENABLE | RT_CMD_RX_ENABLE); // Weirdly, keep spamming re-enable receive
 
             // Re-set RXCONFIG
-            nic32[RT_RXCONFIG/4] = 0x0000f60a; // This should be whatever is set in init plus enabling packet reception (| 0x...a)
+            g2_write_32(NIC(RT_RXCONFIG), 0x0000f60a); // This should be whatever is set in init plus enabling packet reception (| 0x...a)
 
             // clear interrupts
             g2_write_16(NIC(RT_INTRSTATUS), 0xffff);

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -31,15 +31,15 @@ static char uint_string_array[11] = {0};
 
 // Pull together all the goodies
 adapter_t adapter_bba = {
-	"Broadband Adapter (HIT-0400)",
-	{ 0 },		// Mac address
-	{ 0 },		// 2-byte alignment pad
-	gaps_detect,
-	rtl_bb_init,
-	rtl_bb_start,
-	rtl_bb_stop,
-	rtl_bb_loop,
-	rtl_bb_tx
+    "Broadband Adapter (HIT-0400)",
+    { 0 },      // Mac address
+    { 0 },      // 2-byte alignment pad
+    gaps_detect,
+    rtl_bb_init,
+    rtl_bb_start,
+    rtl_bb_stop,
+    rtl_bb_loop,
+    rtl_bb_tx
 };
 
 static rtl_status_t rtl = {0};
@@ -85,9 +85,9 @@ static int rtl_bb_rx(void);
 #define NIC(ADDR) (GAPS_BASE + 0x1700 + (ADDR))
 
 /* 8, 16, and 32 bit access to the PCI I/O space (configured by GAPS) */
-static vuc * const nic8 = REGC(NIC(0));
-static vus * const nic16 = REGS(NIC(0));
-static vul * const nic32 = REGL(NIC(0));
+static vuc *const nic8 = REGC(NIC(0));
+static vus *const nic16 = REGS(NIC(0));
+static vul *const nic32 = REGL(NIC(0));
 
 /* 8, 16, and 32 bit access to the PCI MEMMAP space (configured by GAPS) */
 //static vuc *const mem8 = REGC(RTL_MEM | MEM_AREA_P2_BASE);
@@ -98,11 +98,11 @@ static vul *const mem32 = REGL(RTL_MEM | MEM_AREA_P2_BASE);
 #define GAPS_TX_IO_AREA (RTL_MEM | MEM_AREA_P1_BASE)
 
 /* TX buffer pointers */
-static vuc * const txdesc[TX_NB_BUFFERS] = {
-	REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 0)),
-	REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 1)),
-	REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 2)),
-	REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 3))
+static vuc *const txdesc[TX_NB_BUFFERS] = {
+    REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 0)),
+    REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 1)),
+    REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 2)),
+    REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 3))
 };
 
 #define GAPS_DMA_AREA (GAPS_RX_IO_AREA | 0x8000)
@@ -110,35 +110,32 @@ static vuc * const txdesc[TX_NB_BUFFERS] = {
 
 /* Detect a GAPS PCI bridge */
 int gaps_detect(void) {
-	// This pointer's data is always aligned to 4 bytes--just look at the register address!
-	const char *str = (char*)REGC(0xa1001400);
-	if (!memcmp_32bit_eq(str, GAPSPCI_ID, 16/4))
-	{
-		global_bg_color = BBA_BG_COLOR;
-		installed_adapter = BBA_MODEL;
+    // This pointer's data is always aligned to 4 bytes--just look at the register address!
+    const char *str = (char *)REGC(0xa1001400);
+    if(!memcmp_32bit_eq(str, GAPSPCI_ID, 16/4)) {
+        global_bg_color = BBA_BG_COLOR;
+        installed_adapter = BBA_MODEL;
 
         /* Set this to 0 first thing */
         g2_write_32(GAPS_BASE + 0x1414, 0x00000000);
         /* Turn GAPS off */
         g2_write_32(GAPS_BASE + 0x1418, 0x5a14a501);
 
-		return 0;
-	}
-	else
-		return -1;
+        return 0;
+    }
+    else
+        return -1;
 }
 
-static void rtl_reset(void)
-{
+static void rtl_reset(void) {
     /* Soft-reset the chip */
     g2_write_8(NIC(RT_CHIPCMD), RT_CMD_RESET);
 
     /* Wait for it to come back */
-    while (g2_read_8(NIC(RT_CHIPCMD)) & RT_CMD_RESET);
+    while(g2_read_8(NIC(RT_CHIPCMD)) & RT_CMD_RESET);
 }
 
-static void rtl_init(void)
-{
+static void rtl_init(void) {
     unsigned int tmp;
 
     /* Read MAC address */
@@ -153,22 +150,22 @@ static void rtl_init(void)
     rtl.mac[5] = (tmp >> 8) & 0xff;
     memcpy(adapter_bba.mac, rtl.mac, 6);
 
-	/* Soft-reset the chip to clear any garbage from power on */
-	rtl_reset();
+    /* Soft-reset the chip to clear any garbage from power on */
+    rtl_reset();
 
     /* Setup RX buffer */
     g2_write_32(NIC(RT_RXBUF), RTL_MEM);
 
     /* Setup TX buffers */
     for(tmp=0; tmp<TX_NB_BUFFERS; tmp++) {
-        g2_write_32(NIC(RT_TXADDR0 + (tmp*4)), RTL_MEM + (tmp* TX_BUFFER_LEN) + TX_BUFFER_OFFSET);
+        g2_write_32(NIC(RT_TXADDR0 + (tmp * 4)), RTL_MEM + (tmp * TX_BUFFER_LEN) + TX_BUFFER_OFFSET);
     }
 
-	asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
+    asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
 
-	// This is so strange, but ok...
-	// reset it AGAIN...
-	rtl_reset();
+    // This is so strange, but ok...
+    // reset it AGAIN...
+    rtl_reset();
 
     /* Perform some magic enable/disable dance */
     g2_write_8(NIC(RT_CHIPCMD), RT_CMD_RX_ENABLE);
@@ -182,13 +179,13 @@ static void rtl_init(void)
         }
     }
 
-	asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
+    asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
 
     /* Now a dance with the Multicast Register before Enabling */
     g2_write_32(NIC(RT_MAR0), 0x55aaff00);
     g2_write_32(NIC(RT_MAR4), 0xaa5500ff);
 
-    if((g2_read_32(NIC(RT_MAR0)) == 0x55aaff00) && 
+    if((g2_read_32(NIC(RT_MAR0)) == 0x55aaff00) &&
        (g2_read_32(NIC(RT_MAR4)) == 0xaa5500ff)) {
         /* Enable receive and transmit functions */
         g2_write_8(NIC(RT_CHIPCMD), RT_CMD_RX_ENABLE | RT_CMD_TX_ENABLE);
@@ -197,147 +194,147 @@ static void rtl_init(void)
         g2_write_32(NIC(RT_MAR4), 0xffffffff);
     }
 
-	asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
+    asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
 
     /* Disable all interrupts */
     g2_write_16(NIC(RT_INTRMASK), 0);
 /*
-		//
-		// Very strange initialization stuff. Maybe getting this crazy init sequence right doubles the RX transfer
-		// speed, like how getting the GAPS memory-mapping registers right doubled the TX transfer speed? No idea.
-		// NOTE: Maybe these weird packets need to be sent via loopback mode?
-		// All this doesn't appear to be totally necessary--at least, things seem to work well without it. Wonder what it's for.
-		//
+        //
+        // Very strange initialization stuff. Maybe getting this crazy init sequence right doubles the RX transfer
+        // speed, like how getting the GAPS memory-mapping registers right doubled the TX transfer speed? No idea.
+        // NOTE: Maybe these weird packets need to be sent via loopback mode?
+        // All this doesn't appear to be totally necessary--at least, things seem to work well without it. Wonder what it's for.
+        //
 
-		unsigned char * tx_weird = (unsigned char*)(0xa1840000 + 0x6000);
-		unsigned int tx_weird_iter = 0;
+        unsigned char *tx_weird = (unsigned char *)(0xa1840000 + 0x6000);
+        unsigned int tx_weird_iter = 0;
 
-		while(tx_weird_iter < 6)
-		{
-			tx_weird[tx_weird_iter] = 0xff; // broadcast mac
-			tx_weird_iter++;
-		}
-		// iter = 6
-		memcpy(&tx_weird[6], adapter_bba.mac, 6); // bba's mac
-		tx_weird_iter += 6; // iter = 12
-		tx_weird[12] = 0xea; // ethertype
-		tx_weird[13] = 0x5; // err, this makes ethertype 0xea05, since network data is BE... Although LE 0x5ea is 1514--GAPS security thing?
-		tx_weird_iter += 2; // iter = 14
-		// Now for the last 1500 of weird packet 1
-		while(tx_weird_iter < 1514)
-		{
-			tx_weird[tx_weird_iter] = 0x55 + (tx_weird_iter - 14); // weird packet 1 payload
-			tx_weird_iter++;
-		}
-		// iter = 1514
+        while(tx_weird_iter < 6)
+        {
+            tx_weird[tx_weird_iter] = 0xff; // broadcast mac
+            tx_weird_iter++;
+        }
+        // iter = 6
+        memcpy(&tx_weird[6], adapter_bba.mac, 6); // bba's mac
+        tx_weird_iter += 6; // iter = 12
+        tx_weird[12] = 0xea; // ethertype
+        tx_weird[13] = 0x5; // err, this makes ethertype 0xea05, since network data is BE... Although LE 0x5ea is 1514--GAPS security thing?
+        tx_weird_iter += 2; // iter = 14
+        // Now for the last 1500 of weird packet 1
+        while(tx_weird_iter < 1514)
+        {
+            tx_weird[tx_weird_iter] = 0x55 + (tx_weird_iter - 14); // weird packet 1 payload
+            tx_weird_iter++;
+        }
+        // iter = 1514
 
-		asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
+        asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
 
-		// read back/check weird packet 1 payload (bytes)
-		tx_weird_iter = 14;
-		while(tx_weird_iter < 1514)
-		{
-			if( tx_weird[tx_weird_iter] == (unsigned char)(0x55 + (tx_weird_iter - 14)) )
-			{
-				tx_weird_iter++;
-			}
-			else
-			{
-				break;
-			}
-		}
+        // read back/check weird packet 1 payload (bytes)
+        tx_weird_iter = 14;
+        while(tx_weird_iter < 1514)
+        {
+            if(tx_weird[tx_weird_iter] == (unsigned char)(0x55 + (tx_weird_iter - 14)) )
+            {
+                tx_weird_iter++;
+            }
+            else
+            {
+                break;
+            }
+        }
 
-		if(tx_weird_iter != 1514)
-		{
-			uint_to_string(tx_weird_iter, (unsigned char*)uint_string_array);
-			draw_string(30, 30, uint_string_array, STR_COLOR);
-			uint_to_string(tx_weird[tx_weird_iter], (unsigned char*)uint_string_array);
-			draw_string(130, 30, uint_string_array, STR_COLOR);
-		}
+        if(tx_weird_iter != 1514)
+        {
+            uint_to_string(tx_weird_iter, (unsigned char *)uint_string_array);
+            draw_string(30, 30, uint_string_array, STR_COLOR);
+            uint_to_string(tx_weird[tx_weird_iter], (unsigned char *)uint_string_array);
+            draw_string(130, 30, uint_string_array, STR_COLOR);
+        }
 
-		asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
+        asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
 
-		unsigned int temp_sr = 0;
-		unsigned int temp_sr2 = 0;
-		asm volatile (
-			"stc SR, %[out]\n\t"
-			"mov %[out], %[out2]\n\t"
-			// preserve S and T
-			"and #0x0f, %[out2]\n\t"
-			// clear IMASK
-			"shlr8 %[out]\n\t"
-			"shll8 %[out]\n\t"
-			// Put S and T back
-			"or %[out], %[out2]\n\t"
-			// Store SR for later
-			"stc SR, %[out]\n\t"
-			// Enable external interrupts
-			"ldc %[out2], SR\n"
-		: [out] "=&r" (temp_sr), [out2] "=z" (temp_sr2) // outputs
-		: // inputs
-		: // clobbers
-		);
+        unsigned int temp_sr = 0;
+        unsigned int temp_sr2 = 0;
+        asm volatile (
+            "stc SR, %[out]\n\t"
+            "mov %[out], %[out2]\n\t"
+            // preserve S and T
+            "and #0x0f, %[out2]\n\t"
+            // clear IMASK
+            "shlr8 %[out]\n\t"
+            "shll8 %[out]\n\t"
+            // Put S and T back
+            "or %[out], %[out2]\n\t"
+            // Store SR for later
+            "stc SR, %[out]\n\t"
+            // Enable external interrupts
+            "ldc %[out2], SR\n"
+        : [out] "=&r" (temp_sr), [out2] "=z" (temp_sr2) // outputs
+        : // inputs
+        : // clobbers
+        );
 
-		nic16[RT_INTRMASK/2] = 0x53; // Enable specific interrupts
+        nic16[RT_INTRMASK/2] = 0x53; // Enable specific interrupts
 
-		asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
+        asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
 
-		// Now do it again...
-		tx_weird_iter = 0;
-		while(tx_weird_iter < 6)
-		{
-			tx_weird[tx_weird_iter] = 0xff; // broadcast mac
-			tx_weird_iter++;
-		}
-		// iter = 6
-		memcpy(&tx_weird[6], adapter_bba.mac, 6); // bba's mac
-		tx_weird_iter += 6; // iter = 12
-		tx_weird[12] = 0xea; // ethertype
-		tx_weird[13] = 0x5; // err, this makes ethertype 0xea05, since network data is BE... Although LE 0x5ea is 1514--GAPS security thing?
-		tx_weird_iter += 2; // iter = 14
-		// Now for the last 1500 of weird packet 2
-		while(tx_weird_iter < 1514)
-		{
-			tx_weird[tx_weird_iter] = 0x5a + (tx_weird_iter - 14); // weird packet 2 payload
-			tx_weird_iter++;
-		}
-		// iter = 1514
+        // Now do it again...
+        tx_weird_iter = 0;
+        while(tx_weird_iter < 6)
+        {
+            tx_weird[tx_weird_iter] = 0xff; // broadcast mac
+            tx_weird_iter++;
+        }
+        // iter = 6
+        memcpy(&tx_weird[6], adapter_bba.mac, 6); // bba's mac
+        tx_weird_iter += 6; // iter = 12
+        tx_weird[12] = 0xea; // ethertype
+        tx_weird[13] = 0x5; // err, this makes ethertype 0xea05, since network data is BE... Although LE 0x5ea is 1514--GAPS security thing?
+        tx_weird_iter += 2; // iter = 14
+        // Now for the last 1500 of weird packet 2
+        while(tx_weird_iter < 1514)
+        {
+            tx_weird[tx_weird_iter] = 0x5a + (tx_weird_iter - 14); // weird packet 2 payload
+            tx_weird_iter++;
+        }
+        // iter = 1514
 
-		asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
+        asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
 
-		// read back/check weird packet 2 payload (words)
-		tx_weird_iter = 14;
-		while(tx_weird_iter < 1514)
-		{
-			if( ((unsigned short*)tx_weird)[tx_weird_iter/2] == ( (unsigned char)(0x5a + (tx_weird_iter - 14)) | ( (unsigned short)((unsigned char)(0x5a + (tx_weird_iter - 13))) << 8) ) )
-			{
-				tx_weird_iter += 2;
-			}
-			else
-			{
-				break;
-			}
-		}
+        // read back/check weird packet 2 payload (words)
+        tx_weird_iter = 14;
+        while(tx_weird_iter < 1514)
+        {
+            if( ((unsigned short*)tx_weird)[tx_weird_iter/2] == ( (unsigned char)(0x5a + (tx_weird_iter - 14)) | ( (unsigned short)((unsigned char)(0x5a + (tx_weird_iter - 13))) << 8) ) )
+            {
+                tx_weird_iter += 2;
+            }
+            else
+            {
+                break;
+            }
+        }
 
-		if(tx_weird_iter != 1514)
-		{
-			uint_to_string(tx_weird_iter, (unsigned char*)uint_string_array);
-			draw_string(230, 30, uint_string_array, STR_COLOR);
-			uint_to_string(tx_weird[tx_weird_iter], (unsigned char*)uint_string_array);
-			draw_string(330, 30, uint_string_array, STR_COLOR);
-		}
+        if(tx_weird_iter != 1514)
+        {
+            uint_to_string(tx_weird_iter, (unsigned char *)uint_string_array);
+            draw_string(230, 30, uint_string_array, STR_COLOR);
+            uint_to_string(tx_weird[tx_weird_iter], (unsigned char *)uint_string_array);
+            draw_string(330, 30, uint_string_array, STR_COLOR);
+        }
 
-		asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
+        asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
 
-		nic16[RT_INTRMASK/2] = 0; // Disable interrupts because we don't want them
-		// Restore SR
-		asm volatile ("ldc %[in], SR\n"
-		: // outputs
-		: [in] "r" (temp_sr) // inputs
-		: "t" // clobbers
-		);
+        nic16[RT_INTRMASK/2] = 0; // Disable interrupts because we don't want them
+        // Restore SR
+        asm volatile ("ldc %[in], SR\n"
+        : // outputs
+        : [in] "r" (temp_sr) // inputs
+        : "t" // clobbers
+        );
 
-		asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
+        asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
 */
 
 // TODO tune twister seems like a useful thing
@@ -355,18 +352,18 @@ static void rtl_init(void)
     /* Enable writing to the config registers */
     g2_write_8(NIC(RT_CFG9346), 0xc0);
 
-	/* Disable power management (zeroes are otherwise default values) */
-	// and 	/* Set the driver-loaded bit (0x20) */
-	// LEDs are apparently meant to be set to 0b10. Maybe those pins are repurposed?
-    g2_write_8(NIC(RT_CONFIG1), (g2_read_8(NIC(RT_CONFIG1)) & 
+    /* Disable power management (zeroes are otherwise default values) */
+    // and  /* Set the driver-loaded bit (0x20) */
+    // LEDs are apparently meant to be set to 0b10. Maybe those pins are repurposed?
+    g2_write_8(NIC(RT_CONFIG1), (g2_read_8(NIC(RT_CONFIG1)) &
         ~(RT_CONFIG1_LED0)) | RT_CONFIG1_DVRLOAD | RT_CONFIG1_LED1);
 
     /* Enable FIFO auto-clear */
     g2_write_8(NIC(RT_CONFIG4), g2_read_8(NIC(RT_CONFIG4)) | RT_CONFIG4_RxFIFIOAC);
 
-	// Make internal FIFO address pointer increment downwards
-	// This apparently can be set without unlocking the EEPROM,
-	// but might as well keep it here with the others.
+    // Make internal FIFO address pointer increment downwards
+    // This apparently can be set without unlocking the EEPROM,
+    // but might as well keep it here with the others.
     /* Disable Link-Down Power Saver - this may have not been intended based on the previous comment*/
     g2_write_8(NIC(RT_CONFIG5), g2_read_8(NIC(RT_CONFIG5)) | RT_CONFIG5_LDPS);
 
@@ -380,7 +377,7 @@ static void rtl_init(void)
     /* Disable all multi-interrupts */
     g2_write_16(NIC(RT_MULTIINTR), 0);
 
-	/* clear all interrupts */
+    /* clear all interrupts */
     g2_write_16(NIC(RT_INTRSTATUS), 0xffff);
 
     /* Reset RXMISSED counter */
@@ -392,27 +389,26 @@ static void rtl_init(void)
     /* Reset, Enable, and start auto-negotiation */
     g2_write_16(NIC(RT_MII_BMCR), RT_MII_RESET | RT_MII_AN_ENABLE | RT_MII_AN_START);
 
-	/* Initialize status vars */
-	rtl.cur_tx = 0;
-	rtl.cur_rx = 0;
+    /* Initialize status vars */
+    rtl.cur_tx = 0;
+    rtl.cur_rx = 0;
 
     /* Enable receiving broadcast and physical match packets */
     g2_write_32(NIC(RT_RXCONFIG), g2_read_32(NIC(RT_RXCONFIG)) | RT_RXC_APM | RT_RXC_AB);
 }
 
-int rtl_bb_init(void)
-{
-	int i;
+int rtl_bb_init(void) {
+    int i;
 
-	// The BBA uses the range 0x01840000-0x0184ffff for TX and RX (with usage above
-	// 0x01848000 apparently for GAPS DMA), plus the 2 bytes at 0x0183fffc for... something
+    // The BBA uses the range 0x01840000-0x0184ffff for TX and RX (with usage above
+    // 0x01848000 apparently for GAPS DMA), plus the 2 bytes at 0x0183fffc for... something
 
     /* Initialize the "GAPS" PCI glue controller. */
-	// NOTE: Setting 0x5a14a500 turns off GAPS.
+    // NOTE: Setting 0x5a14a500 turns off GAPS.
     g2_write_32(GAPS_BASE + 0x1418, 0x5a14a501);    /* M */
     i = 10000;
-	// This delay is probably the part where the RealTek 8139C datasheet says to
-	// wait 2ms for the chip to powerup and load its config from its EEPROM
+    // This delay is probably the part where the RealTek 8139C datasheet says to
+    // wait 2ms for the chip to powerup and load its config from its EEPROM
     while(!(g2_read_32(GAPS_BASE + 0x1418) & 1) && i > 0)
         i--;
 
@@ -424,22 +420,22 @@ int rtl_bb_init(void)
     g2_write_32(GAPS_BASE + 0x1420, 0x01000000);
     g2_write_32(GAPS_BASE + 0x1424, 0x01000000);
     g2_write_32(GAPS_BASE + 0x1428, RTL_MEM);       /* DMA Base */
-	/* Register offset 0x142c controls where the image area at GAPS offset 0x8000 (so 0x01848000) points to, which is used by DMA */
+    /* Register offset 0x142c controls where the image area at GAPS offset 0x8000 (so 0x01848000) points to, which is used by DMA */
     g2_write_32(GAPS_BASE + 0x1414, 0x00000001); // Interrupt-related...? (Whatever this is, it gets 1 written to it a couple times, and gets a zero written to it in the same places where 0x1418 gets the turn-off code...)
     g2_write_32(GAPS_BASE + 0x1434, 0x00000001);
 
-	// There appears to be a register at offset 0x1410, which has 0x0c003000 in it. This appears to be a pretty random address in the syscall area.
-	// It doesn't seem to be used for anything, though, and it just seems to get read from in its unused function--it's never written to.
-	// Similarly, 0x1430 has 0x00000010 in it, who knows what for. This one doesn't even have an unused function for it.
+    // There appears to be a register at offset 0x1410, which has 0x0c003000 in it. This appears to be a pretty random address in the syscall area.
+    // It doesn't seem to be used for anything, though, and it just seems to get read from in its unused function--it's never written to.
+    // Similarly, 0x1430 has 0x00000010 in it, who knows what for. This one doesn't even have an unused function for it.
 
-	// Now configure the RTL8139's PCI configuration
+    // Now configure the RTL8139's PCI configuration
 
-	// VEN:DEV is 11db:1234 (vendor code is "Sega Enterprises, LTD")
-	// The GAPS bridge is really just an MMU with a memory buffer that maps the RTL8139C to the Dreamcast's memory space,
-	// so these are actually the PCI configuration registers for the RTL8139, not GAPS (those are just the 0x1400 regs).
-	// It has a custom ven:dev ID, but the class ID in 0x1608 indicates a network controller (byte 0x160b = 0x02 = network controller, 0x160a = 0x00 = Ethernet controller)
-	// See PCI Local Bus Specification 2.2 (2.3 has all the 2.2 stuff in it and the RTL8139C uses 2.2)
-	// This is also documented in the RTL8139C's datasheet, under "PCI Configuration Space Registers"
+    // VEN:DEV is 11db:1234 (vendor code is "Sega Enterprises, LTD")
+    // The GAPS bridge is really just an MMU with a memory buffer that maps the RTL8139C to the Dreamcast's memory space,
+    // so these are actually the PCI configuration registers for the RTL8139, not GAPS (those are just the 0x1400 regs).
+    // It has a custom ven:dev ID, but the class ID in 0x1608 indicates a network controller (byte 0x160b = 0x02 = network controller, 0x160a = 0x00 = Ethernet controller)
+    // See PCI Local Bus Specification 2.2 (2.3 has all the 2.2 stuff in it and the RTL8139C uses 2.2)
+    // This is also documented in the RTL8139C's datasheet, under "PCI Configuration Space Registers"
     g2_write_16(GAPS_BASE + 0x1606, 0xf900);     /* PCI Status Register */
     g2_write_32(GAPS_BASE + 0x1630, 0x00000000); /* PCI BMAR */
     g2_write_8(GAPS_BASE + 0x163c, 0x00);        /* Interrupt Line */
@@ -453,8 +449,7 @@ int rtl_bb_init(void)
     g2_write_32(GAPS_BASE + 0x1614, 0x01000000); /* BAR1 (Memory BAR) */
 
     /* There are two extra regs here that are GAPS-specific (0x1650 and 0x1654). */
-    if(g2_read_8(GAPS_BASE + 0x1650) & 0x1)
-    {
+    if(g2_read_8(GAPS_BASE + 0x1650) & 0x1) {
         g2_write_16(GAPS_BASE + 0x1654, (g2_read_16(GAPS_BASE + 0x1654) & 0xfffc) | 0x8000);
     }
 
@@ -462,8 +457,8 @@ int rtl_bb_init(void)
     g2_write_32(GAPS_BASE + 0x1414, 0x00000001); /* Interrupt enable */
 
     /* Clear GAPS mem */
-	memset_zeroes_64bit((void*)RTL_MEM, 32768/8);
-	CacheBlockPurge((void*)RTL_MEM, 32768/32); // Write back and invalidate the cache over that area since it's volatile
+    memset_zeroes_64bit((void *)RTL_MEM, 32768/8);
+    CacheBlockPurge((void *)RTL_MEM, 32768/32); // Write back and invalidate the cache over that area since it's volatile
 
     /* Another magic number sequence, possibly checking previous init. */
     /* ASCII for 'SEGA' in little-endian */
@@ -488,457 +483,430 @@ int rtl_bb_init(void)
     return -3;
 }
 
-void rtl_bb_start(void)
-{
-	g2_write_32(NIC(RT_RXCONFIG), g2_read_32(NIC(RT_RXCONFIG)) | (RT_RXC_APM | RT_RXC_AB));
+void rtl_bb_start(void) {
+    g2_write_32(NIC(RT_RXCONFIG), g2_read_32(NIC(RT_RXCONFIG)) | (RT_RXC_APM | RT_RXC_AB));
 }
 
-void rtl_bb_stop(void)
-{
+void rtl_bb_stop(void) {
     g2_write_32(NIC(RT_RXCONFIG), g2_read_32(NIC(RT_RXCONFIG)) & ~(RT_RXC_APM | RT_RXC_AB));
 }
 
-int rtl_bb_tx(unsigned char * pkt, int len) // pg. 15 in RTL8139C datasheet: http://realtek.info/pdf/rtl8139cp.pdf
-{
-	// According to KOS source we gotta wait for G2 FIFO to be empty by checking
-	// this bit before reading from/writing to G2. So do that here.
-	while((*(volatile unsigned int*)0xa05f688c) & 0x20U);
+// pg. 15 in RTL8139C datasheet: http://realtek.info/pdf/rtl8139cp.pdf
+int rtl_bb_tx(unsigned char *pkt, int len) {
+    // According to KOS source we gotta wait for G2 FIFO to be empty by checking
+    // this bit before reading from/writing to G2. So do that here.
+    while((*(volatile unsigned int *)0xa05f688c) & 0x20U);
 
-	while (!(nic32[RT_TXSTATUS0/4 + rtl.cur_tx] & 0x2000U))
-	{ // While tx is not complete (checking OWN)
-		if (nic32[RT_TXSTATUS0/4 + rtl.cur_tx] & 0x40000000U)
-		{ // Check for abort
-			// Found another bug: (nic32[RT_TXSTATUS0/4 + rtl.cur_tx] |= 1; // <-- If abort, set descriptor size to 1)
-			// |= the length to 1 doesn't do anything if the length is an odd number >= 1...
-			// Should probably be RT_TXCONFIG register |= 1, which clears abort state and retransmits, see pg 21 of RTL8139C or pg 17 of RTL8139D datasheet
-			nic32[RT_TXCONFIG/4] |= 0x1;
-		}
-	}
+    while(!(nic32[RT_TXSTATUS0/4 + rtl.cur_tx] & 0x2000U)) {
+        // While tx is not complete (checking OWN)
+        if(nic32[RT_TXSTATUS0/4 + rtl.cur_tx] & 0x40000000U) {
+            // Check for abort
+            // Found another bug: (nic32[RT_TXSTATUS0/4 + rtl.cur_tx] |= 1; // <-- If abort, set descriptor size to 1)
+            // |= the length to 1 doesn't do anything if the length is an odd number >= 1...
+            // Should probably be RT_TXCONFIG register |= 1, which clears abort state and retransmits, see pg 21 of RTL8139C or pg 17 of RTL8139D datasheet
+            nic32[RT_TXCONFIG/4] |= 0x1;
+        }
+    }
 
 // Tx time
 #ifdef TX_LOOP_TIMING
-		unsigned long long int first_array = PMCR_RegRead(DCLOAD_PMCR);
+    unsigned long long int first_array = PMCR_RegRead(DCLOAD_PMCR);
 #endif
 
-	unsigned char *copyback_pkt_base = to_p1(&pkt[-2]); // copyback base in cached memory area
+    unsigned char *copyback_pkt_base = to_p1(&pkt[-2]); // copyback base in cached memory area
 
-	__builtin_prefetch(copyback_pkt_base);
+    __builtin_prefetch(copyback_pkt_base);
 
-	// Set GAPS DMA image offset pointer to relevant TX region
-	g2_write_32(GAPS_BASE + 0x142c, (unsigned int)txdesc[rtl.cur_tx]);
+    // Set GAPS DMA image offset pointer to relevant TX region
+    g2_write_32(GAPS_BASE + 0x142c, (unsigned int)txdesc[rtl.cur_tx]);
 
-	/* 8139 doesn't auto-pad */
-	if(len < 60) // This condition may look a little gnarly, but that's because it's meant for speed above all else.
-	{
-		// So pad it.
-		//
-		// We absolutely need to pad this, otherwise prior packets can leak into the
-		// padding. It's called "EtherLeak," and the RTL8139 is apparently a poster
-		// child chipset for the issues that come from lacking auto-pad.
+    /* 8139 doesn't auto-pad */
+    // This condition may look a little gnarly, but that's because it's meant for speed above all else.
+    if(len < 60) {
+        // So pad it.
+        //
+        // We absolutely need to pad this, otherwise prior packets can leak into the
+        // padding. It's called "EtherLeak," and the RTL8139 is apparently a poster
+        // child chipset for the issues that come from lacking auto-pad.
 
-		unsigned int copyback_pkt_offset_len = 2 + len;
-		unsigned int copyback_pkt_len_align4 = copyback_pkt_offset_len & -4; // relative to copyback packet base
-		unsigned int copyback_pkt_extras = copyback_pkt_offset_len - copyback_pkt_len_align4;
-		unsigned int copyback_pkt_extras_end = (copyback_pkt_offset_len + 3) & -4; // This is either equal to or 4 bytes greater than copyback_pkt_len_align4
+        unsigned int copyback_pkt_offset_len = 2 + len;
+        unsigned int copyback_pkt_len_align4 = copyback_pkt_offset_len & -4; // relative to copyback packet base
+        unsigned int copyback_pkt_extras = copyback_pkt_offset_len - copyback_pkt_len_align4;
+        unsigned int copyback_pkt_extras_end = (copyback_pkt_offset_len + 3) & -4; // This is either equal to or 4 bytes greater than copyback_pkt_len_align4
 
-		// Mix in trailing zeros if there are 1, 2, or 3 extra bytes
-		// Using 4-byte alignment for best performance.
-		if(copyback_pkt_extras)
-		{
-			unsigned int last_data = 0x00000000;
+        // Mix in trailing zeros if there are 1, 2, or 3 extra bytes
+        // Using 4-byte alignment for best performance.
+        if(copyback_pkt_extras) {
+            unsigned int last_data = 0x00000000;
 
-			// Need the 4-byte-aligned offset to store this padding-mixed data
-			unsigned int output_offset = copyback_pkt_len_align4;
+            // Need the 4-byte-aligned offset to store this padding-mixed data
+            unsigned int output_offset = copyback_pkt_len_align4;
 
-			last_data |= copyback_pkt_base[copyback_pkt_len_align4++]; // 1 extra byte
+            last_data |= copyback_pkt_base[copyback_pkt_len_align4++]; // 1 extra byte
 
-			if(copyback_pkt_len_align4 != (unsigned int)copyback_pkt_offset_len)
-			{
-				last_data |= (unsigned int)(copyback_pkt_base[copyback_pkt_len_align4++]) << 8; // 2 extra bytes
-			}
+            if(copyback_pkt_len_align4 != (unsigned int)copyback_pkt_offset_len) {
+                last_data |= (unsigned int)(copyback_pkt_base[copyback_pkt_len_align4++]) << 8; // 2 extra bytes
+            }
 
-			if(copyback_pkt_len_align4 != (unsigned int)copyback_pkt_offset_len)
-			{
-				last_data |= (unsigned int)(copyback_pkt_base[copyback_pkt_len_align4]) << 16; // 3 extra bytes
-			}
+            if(copyback_pkt_len_align4 != (unsigned int)copyback_pkt_offset_len) {
+                last_data |= (unsigned int)(copyback_pkt_base[copyback_pkt_len_align4]) << 16; // 3 extra bytes
+            }
 
-			// One 4-byte write instead of up to 3x 1-byte writes. For uncached setups, this makes odd-size
-			// small packets take the same total time to copy to the NIC as multiple-of-4-sized packets,
-			// meaning this is all running as fast as possible.
-			*(unsigned int*)(copyback_pkt_base + output_offset) = last_data;
-		}
+            // One 4-byte write instead of up to 3x 1-byte writes. For uncached setups, this makes odd-size
+            // small packets take the same total time to copy to the NIC as multiple-of-4-sized packets,
+            // meaning this is all running as fast as possible.
+            *(unsigned int *)(copyback_pkt_base + output_offset) = last_data;
+        }
 
-		// Pad the rest of the packet with zeros, if more trailing zeroes need to be written beyond the mixed bytes
-		if(copyback_pkt_extras_end < 64) // The only time this won't be true for small packets is for one with 17 payload bytes.
-		{
-			// 2 unmodified bytes will end up being written to the RTL's TX buffer (since we just want 60 bytes, which offsets
-			// to 62, and 62 then 4-byte-aligns to 64. Offset everything back 2 bytes to undo the internal ethernet alignment
-			// for transmit results in bytes 65-66 getting copied unzeroed), but that's OK here. The RTL8139C will clobber them
-			// with the second half of a 4-byte CRC because it's been configured to append a CRC, anyways--not to mention we set
-			// a length parameter for transmit, which makes those bytes doubly irrelevant.
+        // Pad the rest of the packet with zeros, if more trailing zeroes need to be written beyond the mixed bytes
+        // The only time this won't be true for small packets is for one with 17 payload bytes.
+        if(copyback_pkt_extras_end < 64) {
+            // 2 unmodified bytes will end up being written to the RTL's TX buffer (since we just want 60 bytes, which offsets
+            // to 62, and 62 then 4-byte-aligns to 64. Offset everything back 2 bytes to undo the internal ethernet alignment
+            // for transmit results in bytes 65-66 getting copied unzeroed), but that's OK here. The RTL8139C will clobber them
+            // with the second half of a 4-byte CRC because it's been configured to append a CRC, anyways--not to mention we set
+            // a length parameter for transmit, which makes those bytes doubly irrelevant.
 
-			unsigned int zero_remain = 64 - copyback_pkt_extras_end;
-			unsigned int zeroing_top = (unsigned int)copyback_pkt_base + copyback_pkt_extras_end + zero_remain; // add zero_remain for pre-dec
-			zero_remain /= 4; // will equal 1, 2, 3, 4, or 5
-			unsigned int zero_data = 0;
+            unsigned int zero_remain = 64 - copyback_pkt_extras_end;
+            unsigned int zeroing_top = (unsigned int)copyback_pkt_base + copyback_pkt_extras_end + zero_remain; // add zero_remain for pre-dec
+            zero_remain /= 4; // will equal 1, 2, 3, 4, or 5
+            unsigned int zero_data = 0;
 
-			asm volatile (
-				"clrs\n" // Align for parallelism (CO) - SH4a use "stc SR, Rn" instead with a dummy Rn
-				"dt %[size]\n\t" // Decrement and test size here once to prevent extra jump (EX 1)
-			".align 2\n"
-			"1:\n\t"
-				// *--nextd = val
-				"mov.l %[data], @-%[out]\n\t" // (LS 1/1)
-				"bf.s 1b\n\t" // (BR 1/2)
-				" dt %[size]\n\t" // (--size) ? 0 -> T : 1 -> T (EX 1)
-				: [out] "+r" (zeroing_top), [size] "+&r" (zero_remain) // outputs
-				: [data] "r" (zero_data) // inputs
-				: "t", "memory" // clobbers
-			);
+            asm volatile (
+                "clrs\n" // Align for parallelism (CO) - SH4a use "stc SR, Rn" instead with a dummy Rn
+                "dt %[size]\n\t" // Decrement and test size here once to prevent extra jump (EX 1)
+            ".align 2\n"
+            "1:\n\t"
+                // *--nextd = val
+                "mov.l %[data], @-%[out]\n\t" // (LS 1/1)
+                "bf.s 1b\n\t" // (BR 1/2)
+                " dt %[size]\n\t" // (--size) ? 0 -> T : 1 -> T (EX 1)
+                : [out] "+r" (zeroing_top), [size] "+&r" (zero_remain) // outputs
+                : [data] "r" (zero_data) // inputs
+                : "t", "memory" // clobbers
+            );
 //
 // GCC does a mediocre job of optimizing memset on SH4 for some reason.
 // So, for reference, the above assembly just does this (except each loop takes only 2 cycles per iteration):
 //
-//			unsigned int zero_remain = (64 - copyback_pkt_extras_end) / 4;
-//			unsigned int * zeroing_base = (unsigned int*)(copyback_pkt_base + copyback_pkt_extras_end);
+//          unsigned int zero_remain = (64 - copyback_pkt_extras_end) / 4;
+//          unsigned int * zeroing_base = (unsigned int*)(copyback_pkt_base + copyback_pkt_extras_end);
 //
-//			while(zero_remain--)
-//			{
-//				*zeroing_base++ = 0;
-//			}
+//          while(zero_remain--)
+//          {
+//              *zeroing_base++ = 0;
+//          }
 //
 // See DreamHAL for a complete set of similarly highly-optimized SH4 functions
 //
-		}
+        }
 
-		// Synchronize zeroed out data with tx buffer
-		// Note that 60 bytes would be offset by 62, still within 2nd cache block
-		// But we write to 64 bytes... which is still within the 2nd cache block ;).
-		CacheBlockWriteBack((unsigned char*)(copyback_pkt_base + 32), 1);
+        // Synchronize zeroed out data with tx buffer
+        // Note that 60 bytes would be offset by 62, still within 2nd cache block
+        // But we write to 64 bytes... which is still within the 2nd cache block ;).
+        CacheBlockWriteBack((unsigned char *)(copyback_pkt_base + 32), 1);
 
-		len = 60; // Finally, set length for transmit
+        len = 60; // Finally, set length for transmit
 
-		// NOTE: The reason the minimum length is hardcoded to 60 is because the minimum
-		// frame size allowed is 46 bytes + 14 byte ethernet header. Well, it's actually 64,
-		// but the NIC is configured to auto-append a 4-byte CRC.
-	}
+        // NOTE: The reason the minimum length is hardcoded to 60 is because the minimum
+        // frame size allowed is 46 bytes + 14 byte ethernet header. Well, it's actually 64,
+        // but the NIC is configured to auto-append a 4-byte CRC.
+    }
 
-	// Copy packet over to RTL via GAPS while also accounting for dcload-ip's packet alignment offset
-	SH4_mem_to_pkt_X_movca_32((unsigned char*)GAPS_DMA_AREA, copyback_pkt_base, len);
-	// Technically this will prefetch beyond 1536 for packets between 1504 and 1514 in size, but that's not an issue.
+    // Copy packet over to RTL via GAPS while also accounting for dcload-ip's packet alignment offset
+    SH4_mem_to_pkt_X_movca_32((unsigned char *)GAPS_DMA_AREA, copyback_pkt_base, len);
+    // Technically this will prefetch beyond 1536 for packets between 1504 and 1514 in size, but that's not an issue.
 
 // Tx time end
 #ifdef TX_LOOP_TIMING
-		unsigned long long int second_array = PMCR_RegRead(DCLOAD_PMCR);
-		unsigned int loop_difference = (unsigned int)(second_array - first_array);
+    unsigned long long int second_array = PMCR_RegRead(DCLOAD_PMCR);
+    unsigned int loop_difference = (unsigned int)(second_array - first_array);
 
-		clear_lines(222, 24, global_bg_color);
-		uint_to_string_dec(loop_difference, (char*)uint_string_array);
-		draw_string(30, 222, uint_string_array, STR_COLOR);
+    clear_lines(222, 24, global_bg_color);
+    uint_to_string_dec(loop_difference, (char*)uint_string_array);
+    draw_string(30, 222, uint_string_array, STR_COLOR);
 #endif
 
-	// Set len (SIZE field), destructively zeroing out all other R/W settings. OWN needs to be cleared by software; it does here.
-	// Software writes don't impact the read-only bits.
-	// Zeroing also sets Early FIFO TX threshold to 8 bytes.
-	// Finally, writing to the status register triggers the packet send.
-		nic32[RT_TXSTATUS0/4 + rtl.cur_tx] = len | 0x20000; // Set Early TX to 64 bytes
-	//nic32[RT_TXSTATUS0/4 + rtl.cur_tx] = len | 0x10000; // Set Early TX to 32 bytes
-//	nic32[RT_TXSTATUS0/4 + rtl.cur_tx] = len;
+    // Set len (SIZE field), destructively zeroing out all other R/W settings. OWN needs to be cleared by software; it does here.
+    // Software writes don't impact the read-only bits.
+    // Zeroing also sets Early FIFO TX threshold to 8 bytes.
+    // Finally, writing to the status register triggers the packet send.
+    nic32[RT_TXSTATUS0/4 + rtl.cur_tx] = len | 0x20000; // Set Early TX to 64 bytes
+    //nic32[RT_TXSTATUS0/4 + rtl.cur_tx] = len | 0x10000; // Set Early TX to 32 bytes
+    //nic32[RT_TXSTATUS0/4 + rtl.cur_tx] = len;
 
-	rtl.cur_tx = (rtl.cur_tx + 1) % 4; // Move to next txdesc buffer
+    rtl.cur_tx = (rtl.cur_tx + 1) % 4; // Move to next txdesc buffer
 
-	return 1;
+    return 1;
 }
 
-static void pktcpy(unsigned char *dest, unsigned char *src, unsigned int n) // dest and src should already be in a copyback memory region
-{
-	if (n > RX_PKT_BUF_SIZE)
-		return;
+// dest and src should already be in a copyback memory region
+static void pktcpy(unsigned char *dest, unsigned char *src, unsigned int n) {
+    if(n > RX_PKT_BUF_SIZE)
+        return;
 
-	// According to KOS source we gotta wait for G2 FIFO to be empty by checking
-	// this bit before reading from/writing to G2. So do that here.
-	while((*(volatile unsigned int*)0xa05f688c) & 0x20U);
+    // According to KOS source we gotta wait for G2 FIFO to be empty by checking
+    // this bit before reading from/writing to G2. So do that here.
+    while((*(volatile unsigned int *)0xa05f688c) & 0x20U);
 
-	// Set GAPS DMA image offset pointer to relevant RX region
-	//--	g2_write_32(GAPS_BASE + 0x142c, (unsigned int)src);
-	g2_write_32(GAPS_BASE + 0x142c, (unsigned int)src - 2); // Yup, this works. So we can just use memcpy_32bit()
+    // Set GAPS DMA image offset pointer to relevant RX region
+    //--    g2_write_32(GAPS_BASE + 0x142c, (unsigned int)src);
+    g2_write_32(GAPS_BASE + 0x142c, (unsigned int)src - 2); // Yup, this works. So we can just use memcpy_32bit()
 
-	// NOWRAP
-	// Note: the +3 may mean we read some of the CRC for not-byte-multiple packets. That's fine: it doesn't cause us any problems.
-	//--	SH4_pkt_to_mem_X_movca_32(dest, (unsigned char*)0x01848000, n); // This takes full n now
-	//SH4_pkt_to_mem_X_movca_32_linear(dest, (unsigned char*)0x01848000, n + 2); // This takes full n now
-	memcpy_32bit(dest, (unsigned char*)GAPS_DMA_AREA, (n + 2 + 3)/4); // Lol this is as fast as the asm functions
-	CacheBlockInvalidate((unsigned char*)GAPS_DMA_AREA, (n + 2 + 31)/32); // Need to invalidate the src packet
-	CacheBlockWriteBack(dest, (2 + n + 31)/32);
+    // NOWRAP
+    // Note: the +3 may mean we read some of the CRC for not-byte-multiple packets. That's fine: it doesn't cause us any problems.
+    //--    SH4_pkt_to_mem_X_movca_32(dest, (unsigned char*)0x01848000, n); // This takes full n now
+    //SH4_pkt_to_mem_X_movca_32_linear(dest, (unsigned char*)0x01848000, n + 2); // This takes full n now
+    memcpy_32bit(dest, (unsigned char *)GAPS_DMA_AREA, (n + 2 + 3)/4); // Lol this is as fast as the asm functions
+    CacheBlockInvalidate((unsigned char *)GAPS_DMA_AREA, (n + 2 + 31)/32); // Need to invalidate the src packet
+    CacheBlockWriteBack(dest, (2 + n + 31)/32);
 }
 
-static int rtl_bb_rx()
-{
-	int processed;
-	unsigned int rx_status;
-	unsigned int rx_size, pkt_size, ring_offset;
-	unsigned char *pkt;
+static int rtl_bb_rx() {
+    int processed;
+    unsigned int rx_status;
+    unsigned int rx_size, pkt_size, ring_offset;
+    unsigned char *pkt;
 
-	processed = 0;
+    processed = 0;
 
-	/* While we have frames left to process... */
-	while (!(nic8[RT_CHIPCMD] & 1))
-	{
+    /* While we have frames left to process... */
+    while(!(nic8[RT_CHIPCMD] & 1)) {
 
-		/* Get frame size and status */
-		// Don't need the % there for nowrap since it happens later.
-		ring_offset = rtl.cur_rx;
-		// Use uncached area for this intentionally, in case of rtl_is_copying.
-		// Don't want to accidentally cache an unfinished packet.
-		// This also means we don't have to worry about invalidating a block holding the status byte. Nice!
-		rx_status = mem32[0x0000/4 + ring_offset/4];
-		rx_size = (rx_status >> 16) & 0xffffU;
+        /* Get frame size and status */
+        // Don't need the % there for nowrap since it happens later.
+        ring_offset = rtl.cur_rx;
+        // Use uncached area for this intentionally, in case of rtl_is_copying.
+        // Don't want to accidentally cache an unfinished packet.
+        // This also means we don't have to worry about invalidating a block holding the status byte. Nice!
+        rx_status = mem32[0x0000/4 + ring_offset/4];
+        rx_size = (rx_status >> 16) & 0xffffU;
 
-		/* apparently this means the rtl8139 is still copying */
-		if (rx_size == 0xfff0U)
-		{
-			rtl_is_copying = 1; // Really don't want to run a DHCP renewal while data is in flight...
-			break;
-		}
-		rtl_is_copying = 0;
+        /* apparently this means the rtl8139 is still copying */
+        if(rx_size == 0xfff0U) {
+            rtl_is_copying = 1; // Really don't want to run a DHCP renewal while data is in flight...
+            break;
+        }
+        rtl_is_copying = 0;
 
-		pkt_size = rx_size - 4;
+        pkt_size = rx_size - 4;
 
 // Full loop timing
 #ifdef FULL_TRIP_TIMING
-    unsigned long long int first_array1 = PMCR_RegRead(DCLOAD_PMCR);
+        unsigned long long int first_array1 = PMCR_RegRead(DCLOAD_PMCR);
 #endif
 
-		if ((rx_status & 1) && (pkt_size <= RX_PKT_BUF_SIZE))
-		{
-			pkt = (unsigned char*)(GAPS_RX_IO_AREA + 0x0000 + ring_offset + 4); // + 4 to skip the status byte (DMA)
+        if((rx_status & 1) && (pkt_size <= RX_PKT_BUF_SIZE)) {
+            pkt = (unsigned char *)(GAPS_RX_IO_AREA + 0x0000 + ring_offset + 4); // + 4 to skip the status byte (DMA)
 
 // Rx time
 #ifdef RX_LOOP_TIMING
-			unsigned long long int first_array = PMCR_RegRead(DCLOAD_PMCR);
+            unsigned long long int first_array = PMCR_RegRead(DCLOAD_PMCR);
 #endif
 
-			pktcpy(raw_current_pkt, pkt, pkt_size); // SH4_pkt_to_mem() will shift it by 2 for current_pkt
+            pktcpy(raw_current_pkt, pkt, pkt_size); // SH4_pkt_to_mem() will shift it by 2 for current_pkt
 
 // Rx time end
 #ifdef RX_LOOP_TIMING
-		unsigned long long int second_array = PMCR_RegRead(DCLOAD_PMCR);
-		unsigned int loop_difference = (unsigned int)(second_array - first_array);
+            unsigned long long int second_array = PMCR_RegRead(DCLOAD_PMCR);
+            unsigned int loop_difference = (unsigned int)(second_array - first_array);
 
-		clear_lines(246, 24, global_bg_color);
-		uint_to_string_dec(loop_difference, (char*)uint_string_array);
-		draw_string(30, 246, uint_string_array, STR_COLOR);
+            clear_lines(246, 24, global_bg_color);
+            uint_to_string_dec(loop_difference, (char *)uint_string_array);
+            draw_string(30, 246, uint_string_array, STR_COLOR);
 #endif
 
 // Process time
 #ifdef PKT_PROCESS_TIMING
-			asm volatile ("nop\n" : : : "memory");
-		unsigned long long int	first_array2 = PMCR_RegRead(DCLOAD_PMCR);
+            asm volatile ("nop\n" : : : "memory");
+            unsigned long long int  first_array2 = PMCR_RegRead(DCLOAD_PMCR);
 #endif
 
-			//process_pkt(current_pkt);
-			process_pkt(to_p1(current_pkt));
+            //process_pkt(current_pkt);
+            process_pkt(to_p1(current_pkt));
 
 // Process time end
 #ifdef PKT_PROCESS_TIMING
-		unsigned long long int second_array2 = PMCR_RegRead(DCLOAD_PMCR);
-		unsigned int loop_difference2 = (unsigned int)(second_array2 - first_array2);
+            unsigned long long int second_array2 = PMCR_RegRead(DCLOAD_PMCR);
+            unsigned int loop_difference2 = (unsigned int)(second_array2 - first_array2);
 
-		clear_lines(270, 24, global_bg_color);
-		uint_to_string_dec(loop_difference2, (char*)uint_string_array);
-		draw_string(30, 270, uint_string_array, STR_COLOR);
+            clear_lines(270, 24, global_bg_color);
+            uint_to_string_dec(loop_difference2, (char *)uint_string_array);
+            draw_string(30, 270, uint_string_array, STR_COLOR);
 #endif
 
-		}
+        }
 
-		// Align next packet to 4-bytes (add 4 to account for transmit status; the 4 extra bytes included in rx_size are the CRC)
-		rtl.cur_rx = (rtl.cur_rx + rx_size + 4 + 3) & ~3;
+        // Align next packet to 4-bytes (add 4 to account for transmit status; the 4 extra bytes included in rx_size are the CRC)
+        rtl.cur_rx = (rtl.cur_rx + rx_size + 4 + 3) & ~3;
 
-		if(rtl.cur_rx >= RX_BUFFER_LEN)
-		{
-			// Prevent underflowing the RX buffer
-			rtl.cur_rx %= RX_BUFFER_LEN;
-			nic16[RT_RXBUFTAIL/2] = 0x7ff0;
-			// According to the RTL8139C datasheet, 0xfff0 = 65520 is the default value of the register,
-			// and the register cannot be written to before data has been read from the buffer for some
-			// reason. So, presumably, we can just use that value here.
-			//
-			// Although, in the specific case of this system with the GAPS PCI Bridge, we can also just use
-			// 0x7ff0 since that's a well-known memory location (it's the last 16 bytes of the last txdesc.
-			// Because each txdesc is 2048 bytes and no more than 1536 bytes will ever be written there, it
-			// seems like a pretty safe place to put... whatever that apparently 100% necessary offset of
-			// -16 is for).
-		}
-		else
-		{
-			rtl.cur_rx %= RX_BUFFER_LEN;
-			nic16[RT_RXBUFTAIL/2] = rtl.cur_rx - 16;
-			// Why 16? NetBSD and Linux do this, too. Status is 4, CRC appended is 4, what's the other 8?
-			// Things don't work if this isn't 16, anyways (I tried changing it). Maybe this is 16 for DMA reasons?
-			// RealTek does it here: https://www.cs.usfca.edu/~cruse/cs326f04/RTL8139_ProgrammersGuide.pdf
-			// Maybe this is why 16: initial value is 0x0fff0 according to the RTL8139C datasheet:
-			// https://people.freebsd.org/~wpaul/RealTek/spec-8139c(160).pdf
-			// This stays the same regardless of wrap/nowrap, as well.
-			// Wow, even QEMU emulates this "off by 16" thing here: https://github.com/qemu/qemu/blob/master/hw/net/rtl8139.c#L2532
-		}
+        if(rtl.cur_rx >= RX_BUFFER_LEN) {
+            // Prevent underflowing the RX buffer
+            rtl.cur_rx %= RX_BUFFER_LEN;
+            nic16[RT_RXBUFTAIL/2] = 0x7ff0;
+            // According to the RTL8139C datasheet, 0xfff0 = 65520 is the default value of the register,
+            // and the register cannot be written to before data has been read from the buffer for some
+            // reason. So, presumably, we can just use that value here.
+            //
+            // Although, in the specific case of this system with the GAPS PCI Bridge, we can also just use
+            // 0x7ff0 since that's a well-known memory location (it's the last 16 bytes of the last txdesc.
+            // Because each txdesc is 2048 bytes and no more than 1536 bytes will ever be written there, it
+            // seems like a pretty safe place to put... whatever that apparently 100% necessary offset of
+            // -16 is for).
+        }
+        else {
+            rtl.cur_rx %= RX_BUFFER_LEN;
+            nic16[RT_RXBUFTAIL/2] = rtl.cur_rx - 16;
+            // Why 16? NetBSD and Linux do this, too. Status is 4, CRC appended is 4, what's the other 8?
+            // Things don't work if this isn't 16, anyways (I tried changing it). Maybe this is 16 for DMA reasons?
+            // RealTek does it here: https://www.cs.usfca.edu/~cruse/cs326f04/RTL8139_ProgrammersGuide.pdf
+            // Maybe this is why 16: initial value is 0x0fff0 according to the RTL8139C datasheet:
+            // https://people.freebsd.org/~wpaul/RealTek/spec-8139c(160).pdf
+            // This stays the same regardless of wrap/nowrap, as well.
+            // Wow, even QEMU emulates this "off by 16" thing here: https://github.com/qemu/qemu/blob/master/hw/net/rtl8139.c#L2532
+        }
 
-		// Ack it
+        // Ack it
         unsigned short intr = g2_read_16(NIC(RT_INTRSTATUS));
 
         if(intr & RT_INT_RX_ACK)
             g2_write_16(NIC(RT_INTRSTATUS), RT_INT_RX_ACK);
 
-		processed++;
+        processed++;
 
 #ifdef FULL_TRIP_TIMING
-		unsigned long long int second_array1 = PMCR_RegRead(DCLOAD_PMCR);
-		unsigned int loop_difference1 = (unsigned int)(second_array1 - first_array1);
+        unsigned long long int second_array1 = PMCR_RegRead(DCLOAD_PMCR);
+        unsigned int loop_difference1 = (unsigned int)(second_array1 - first_array1);
 
-		clear_lines(412, 24, global_bg_color);
-		uint_to_string_dec(loop_difference1, (char*)uint_string_array);
-		draw_string(30, 412, uint_string_array, STR_COLOR);
+        clear_lines(412, 24, global_bg_color);
+        uint_to_string_dec(loop_difference1, (char *)uint_string_array);
+        draw_string(30, 412, uint_string_array, STR_COLOR);
 #endif
-	}
+    }
 
-	return processed;
+    return processed;
 }
 
-void rtl_bb_loop(int is_main_loop)
-{
-	unsigned int intr = 0;
-	unsigned int loop_start[2] = {0};
-	unsigned int loop_measure[2] = {0};
-	unsigned int prev_loop_elapsed = 0;
+void rtl_bb_loop(int is_main_loop) {
+    unsigned int intr = 0;
+    unsigned int loop_start[2] = {0};
+    unsigned int loop_measure[2] = {0};
+    unsigned int prev_loop_elapsed = 0;
 
-	if(is_main_loop)
-	{
-		if(!(booted || running))
-		{
-			disp_info();
-		}
+    if(is_main_loop) {
+        if(!(booted || running)) {
+            disp_info();
+        }
 
-		// Need to wait for a link change before it's OK to do anything
-		rtl_link_up = 0;
-	}
+        // Need to wait for a link change before it's OK to do anything
+        rtl_link_up = 0;
+    }
 
-	if (timeout_loop > 0)
-	{
-		PMCR_Read(DCLOAD_PMCR, loop_start);
-	}
+    if(timeout_loop > 0) {
+        PMCR_Read(DCLOAD_PMCR, loop_start);
+    }
 
-	// OMG this is polling the network adapter. Well, ok then.
-	while(!escape_loop)
-	{
+    // OMG this is polling the network adapter. Well, ok then.
+    while(!escape_loop) {
 
-		/* Check interrupt status */
-		if (g2_read_16(NIC(RT_INTRSTATUS)) != intr)
-		{
-			intr = g2_read_16(NIC(RT_INTRSTATUS));
+        /* Check interrupt status */
+        if(g2_read_16(NIC(RT_INTRSTATUS)) != intr) {
+            intr = g2_read_16(NIC(RT_INTRSTATUS));
             g2_write_16(NIC(RT_INTRSTATUS), intr & ~RT_INT_RX_ACK);
-		}
+        }
 
-		/* Did we receive some data? */
-		if (intr & RT_INT_RX_ACK)
-		{
-			//i = rtl_bb_rx();
-			rtl_bb_rx();
-		}
+        /* Did we receive some data? */
+        if(intr & RT_INT_RX_ACK) {
+            //i = rtl_bb_rx();
+            rtl_bb_rx();
+        }
 
-		/* link change */
-		if (__builtin_expect(intr & RT_INT_RXFIFO_UNDERRUN, 0))
-		{
+        /* link change */
+        if(__builtin_expect(intr & RT_INT_RXFIFO_UNDERRUN, 0)) {
 
-			if (booted && (!running))
-			{
-				disp_status("link change...");
-			}
+            if(booted && (!running)) {
+                disp_status("link change...");
+            }
 
-			nic16[RT_MII_BMCR/2] = 0x9200;
+            nic16[RT_MII_BMCR/2] = 0x9200;
 
-			/* wait for valid link */
-			while (!(nic16[RT_MII_BMSR/2] & 0x20));
+            /* wait for valid link */
+            while(!(nic16[RT_MII_BMSR/2] & 0x20));
 
-			/* wait for the additional link change interrupt that is coming */
-			while (!(g2_read_16(NIC(RT_INTRSTATUS)) & RT_INT_RXFIFO_UNDERRUN));
+            /* wait for the additional link change interrupt that is coming */
+            while(!(g2_read_16(NIC(RT_INTRSTATUS)) & RT_INT_RXFIFO_UNDERRUN));
             g2_write_16(NIC(RT_INTRSTATUS), RT_INT_RXFIFO_UNDERRUN);
 
-			if (booted && (!running))
-			{
-				disp_status("idle...");
-			}
+            if(booted && (!running)) {
+                disp_status("idle...");
+            }
 
-			/* if we were waiting in a loop with a timeout when link changed, timeout
-			 * immediately upon bringing link back up, so we can retry immediately */
-			if (timeout_loop > 0 )
-			{
-				dhcp_attempts = 0;
-				timeout_loop = -1;
-				escape_loop = 1;
-			}
+            /* if we were waiting in a loop with a timeout when link changed, timeout
+             * immediately upon bringing link back up, so we can retry immediately */
+            if(timeout_loop > 0) {
+                dhcp_attempts = 0;
+                timeout_loop = -1;
+                escape_loop = 1;
+            }
 
-			rtl_link_up = 1; // Good to go!
-		}
+            rtl_link_up = 1; // Good to go!
+        }
 
-		/* Rx FIFO overflow */
-		if (intr & RT_INT_RXFIFO_OVERFLOW)
-		{
-			/* must clear Rx Buffer Overflow too for some reason */
-			// It's an errata (hardware bug/quirk), this needs to be done.
-			g2_write_16(NIC(RT_INTRSTATUS), RT_INT_RXBUF_OVERFLOW);
-		}
+        /* Rx FIFO overflow */
+        if(intr & RT_INT_RXFIFO_OVERFLOW) {
+            /* must clear Rx Buffer Overflow too for some reason */
+            // It's an errata (hardware bug/quirk), this needs to be done.
+            g2_write_16(NIC(RT_INTRSTATUS), RT_INT_RXBUF_OVERFLOW);
+        }
 
-		/* Rx Buffer overflow */
-		if (intr & RT_INT_RXBUF_OVERFLOW)
-		{
+        /* Rx Buffer overflow */
+        if(intr & RT_INT_RXBUF_OVERFLOW) {
 /*
-			// Update CAPR
-			rtl.cur_rx = nic16[RT_RXBUFHEAD];
-			nic16[RT_RXBUFTAIL] = rtl.cur_rx - 16;
-			rtl.cur_rx = 0;
+            // Update CAPR
+            rtl.cur_rx = nic16[RT_RXBUFHEAD];
+            nic16[RT_RXBUFTAIL] = rtl.cur_rx - 16;
+            rtl.cur_rx = 0;
 
-			// Disable receive
-			nic8[RT_CHIPCMD] = RT_CMD_TX_ENABLE;
+            // Disable receive
+            nic8[RT_CHIPCMD] = RT_CMD_TX_ENABLE;
 
-			// Wait for it
-			while ( !(nic8[RT_CHIPCMD] & RT_CMD_RX_ENABLE))
-				nic8[RT_CHIPCMD] = RT_CMD_TX_ENABLE | RT_CMD_RX_ENABLE; // Weirdly, keep spamming re-enable receive
+            // Wait for it
+            while( !(nic8[RT_CHIPCMD] & RT_CMD_RX_ENABLE))
+                nic8[RT_CHIPCMD] = RT_CMD_TX_ENABLE | RT_CMD_RX_ENABLE; // Weirdly, keep spamming re-enable receive
 
-			// Re-set RXCONFIG
-			nic32[RT_RXCONFIG/4] = 0x0000f60a; // This should be whatever is set in init plus enabling packet reception (| 0x...a)
+            // Re-set RXCONFIG
+            nic32[RT_RXCONFIG/4] = 0x0000f60a; // This should be whatever is set in init plus enabling packet reception (| 0x...a)
 
-			// clear interrupts
+            // clear interrupts
             g2_write_16(NIC(RT_INTRSTATUS), 0xffff);
-	*/
-			// NetBSD, FreeBSD, and OpenBSD all just do a full re-init if this happens.
-			rtl_init();
-		}
+    */
+            // NetBSD, FreeBSD, and OpenBSD all just do a full re-init if this happens.
+            rtl_init();
+        }
 
-		if(is_main_loop && rtl_link_up && (!rtl_is_copying)) // Only want this to run in main loop
-		{
-			// Do we need to renew our IP address?
-			// This will override set_ip_from_file() if the ip is in the 0.0.0.0/8 range
-			set_ip_dhcp();
-		}
+        // Only want this to run in main loop
+        if(is_main_loop && rtl_link_up && (!rtl_is_copying)) {
+            // Do we need to renew our IP address?
+            // This will override set_ip_from_file() if the ip is in the 0.0.0.0/8 range
+            set_ip_dhcp();
+        }
 
-		if(timeout_loop > 0)
-		{
-			PMCR_Read(DCLOAD_PMCR, loop_measure);
-			unsigned int loop_secs_elapsed = (unsigned int)((*(unsigned long long int*)loop_measure - *(unsigned long long int*)loop_start)/200000000);
-			if(prev_loop_elapsed != loop_secs_elapsed)
-			{
-				if(dhcp_attempts > 1) // Don't show a counter yet if it's the first attempt
-				{
-					disp_dhcp_attempts_count();
-					disp_dhcp_next_attempt(timeout_loop - loop_secs_elapsed + 1);
-				}
-				if(loop_secs_elapsed > (unsigned int) timeout_loop)
-				{
-					timeout_loop = -1;
-					escape_loop = 1;
-				}
-				prev_loop_elapsed = loop_secs_elapsed;
-			}
-		}
-	}
-	escape_loop = 0;
+        if(timeout_loop > 0) {
+            PMCR_Read(DCLOAD_PMCR, loop_measure);
+            unsigned int loop_secs_elapsed = (unsigned int)((*(unsigned long long int *)loop_measure - *(unsigned long long int *)loop_start)/200000000);
+            if(prev_loop_elapsed != loop_secs_elapsed) {
+                // Don't show a counter yet if it's the first attempt
+                if(dhcp_attempts > 1) {
+                    disp_dhcp_attempts_count();
+                    disp_dhcp_next_attempt(timeout_loop - loop_secs_elapsed + 1);
+                }
+                if(loop_secs_elapsed > (unsigned int) timeout_loop) {
+                    timeout_loop = -1;
+                    escape_loop = 1;
+                }
+                prev_loop_elapsed = loop_secs_elapsed;
+            }
+        }
+    }
+    escape_loop = 0;
 }

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -14,6 +14,7 @@
 #include "dhcp.h"
 #include "memfuncs.h"
 #include "perfctr.h"
+#include "video.h"
 
 /* Performance Testing */
 //#define TX_LOOP_TIMING
@@ -22,7 +23,6 @@
 //#define FULL_TRIP_TIMING
 
 #if defined(TX_LOOP_TIMING) || defined(FULL_TRIP_TIMING) || defined(RX_LOOP_TIMING) || defined(PKT_PROCESS_TIMING)
-    #include "video.h"
     static char uint_string_array[11] = {0};
 #endif
 
@@ -71,6 +71,96 @@ static volatile unsigned char rtl_is_copying = 0;
 static void rtl_init(void);
 
 /* KOS API shim definitions */
+
+static void g2_memzero(unsigned char *copyback_pkt_base, unsigned int len) {
+    // So pad it.
+    //
+    // We absolutely need to pad this, otherwise prior packets can leak into the
+    // padding. It's called "EtherLeak," and the RTL8139 is apparently a poster
+    // child chipset for the issues that come from lacking auto-pad.
+
+    unsigned int copyback_pkt_offset_len = 2 + len;
+    unsigned int copyback_pkt_len_align4 = copyback_pkt_offset_len & -4; // relative to copyback packet base
+    unsigned int copyback_pkt_extras = copyback_pkt_offset_len - copyback_pkt_len_align4;
+    unsigned int copyback_pkt_extras_end = (copyback_pkt_offset_len + 3) & -4; // This is either equal to or 4 bytes greater than copyback_pkt_len_align4
+
+    // Mix in trailing zeros if there are 1, 2, or 3 extra bytes
+    // Using 4-byte alignment for best performance.
+    if(copyback_pkt_extras) {
+        unsigned int last_data = 0x00000000;
+
+        // Need the 4-byte-aligned offset to store this padding-mixed data
+        unsigned int output_offset = copyback_pkt_len_align4;
+
+        last_data |= copyback_pkt_base[copyback_pkt_len_align4++]; // 1 extra byte
+
+        if(copyback_pkt_len_align4 != (unsigned int)copyback_pkt_offset_len) {
+            last_data |= (unsigned int)(copyback_pkt_base[copyback_pkt_len_align4++]) << 8; // 2 extra bytes
+        }
+
+        if(copyback_pkt_len_align4 != (unsigned int)copyback_pkt_offset_len) {
+            last_data |= (unsigned int)(copyback_pkt_base[copyback_pkt_len_align4]) << 16; // 3 extra bytes
+        }
+
+        // One 4-byte write instead of up to 3x 1-byte writes. For uncached setups, this makes odd-size
+        // small packets take the same total time to copy to the NIC as multiple-of-4-sized packets,
+        // meaning this is all running as fast as possible.
+        *(unsigned int *)(copyback_pkt_base + output_offset) = last_data;
+    }
+
+    // Pad the rest of the packet with zeros, if more trailing zeroes need to be written beyond the mixed bytes
+    // The only time this won't be true for small packets is for one with 17 payload bytes.
+    if(copyback_pkt_extras_end < 64) {
+        // 2 unmodified bytes will end up being written to the RTL's TX buffer (since we just want 60 bytes, which offsets
+        // to 62, and 62 then 4-byte-aligns to 64. Offset everything back 2 bytes to undo the internal ethernet alignment
+        // for transmit results in bytes 65-66 getting copied unzeroed), but that's OK here. The RTL8139C will clobber them
+        // with the second half of a 4-byte CRC because it's been configured to append a CRC, anyways--not to mention we set
+        // a length parameter for transmit, which makes those bytes doubly irrelevant.
+
+        unsigned int zero_remain = 64 - copyback_pkt_extras_end;
+        unsigned int zeroing_top = (unsigned int)copyback_pkt_base + copyback_pkt_extras_end + zero_remain; // add zero_remain for pre-dec
+        zero_remain /= 4; // will equal 1, 2, 3, 4, or 5
+        unsigned int zero_data = 0;
+
+        asm volatile (
+            "clrs\n" // Align for parallelism (CO) - SH4a use "stc SR, Rn" instead with a dummy Rn
+            "dt %[size]\n\t" // Decrement and test size here once to prevent extra jump (EX 1)
+        ".align 2\n"
+        "1:\n\t"
+            // *--nextd = val
+            "mov.l %[data], @-%[out]\n\t" // (LS 1/1)
+            "bf.s 1b\n\t" // (BR 1/2)
+            " dt %[size]\n\t" // (--size) ? 0 -> T : 1 -> T (EX 1)
+            : [out] "+r" (zeroing_top), [size] "+&r" (zero_remain) // outputs
+            : [data] "r" (zero_data) // inputs
+            : "t", "memory" // clobbers
+        );
+        //
+        // GCC does a mediocre job of optimizing memset on SH4 for some reason.
+        // So, for reference, the above assembly just does this (except each loop takes only 2 cycles per iteration):
+        //
+        //          unsigned int zero_remain = (64 - copyback_pkt_extras_end) / 4;
+        //          unsigned int * zeroing_base = (unsigned int*)(copyback_pkt_base + copyback_pkt_extras_end);
+        //
+        //          while(zero_remain--)
+        //          {
+        //              *zeroing_base++ = 0;
+        //          }
+        //
+        // See DreamHAL for a complete set of similarly highly-optimized SH4 functions
+        //
+    }
+
+    // Synchronize zeroed out data with tx buffer
+    // Note that 60 bytes would be offset by 62, still within 2nd cache block
+    // But we write to 64 bytes... which is still within the 2nd cache block ;).
+    CacheBlockWriteBack((unsigned char *)(copyback_pkt_base + 32), 1);
+
+    // NOTE: The reason the minimum length is hardcoded to 60 is because the minimum
+    // frame size allowed is 46 bytes + 14 byte ethernet header. Well, it's actually 64,
+    // but the NIC is configured to auto-append a 4-byte CRC.
+}
+
 
 #define g2_write_8(address, value) *((volatile uint8_t *)(address)) = (value)
 #define g2_write_16(address, value) *((volatile uint16_t *)(address)) = (value)
@@ -250,6 +340,147 @@ static vuc *const txdesc[TX_NB_BUFFERS] = {
 
 #define GAPS_DMA_AREA (GAPS_RX_IO_AREA | 0x8000)
 
+/*
+    Very strange initialization stuff. Maybe getting this crazy init sequence right doubles the RX transfer
+    speed, like how getting the GAPS memory-mapping registers right doubled the TX transfer speed? No idea.
+    NOTE: Maybe these weird packets need to be sent via loopback mode?
+    All this doesn't appear to be totally necessary--at least, things seem to work well without it. Wonder what it's for.
+*/
+static void weird_extra_init(void) {
+    unsigned char *tx_weird = (unsigned char *)(0xa1840000 + 0x6000);
+    unsigned int tx_weird_iter = 0;
+
+    while(tx_weird_iter < 6)
+    {
+        tx_weird[tx_weird_iter] = 0xff; // broadcast mac
+        tx_weird_iter++;
+    }
+    // iter = 6
+    memcpy(&tx_weird[6], adapter_bba.mac, 6); // bba's mac
+    tx_weird_iter += 6; // iter = 12
+    tx_weird[12] = 0xea; // ethertype
+    tx_weird[13] = 0x5; // err, this makes ethertype 0xea05, since network data is BE... Although LE 0x5ea is 1514--GAPS security thing?
+    tx_weird_iter += 2; // iter = 14
+    // Now for the last 1500 of weird packet 1
+    while(tx_weird_iter < 1514)
+    {
+        tx_weird[tx_weird_iter] = 0x55 + (tx_weird_iter - 14); // weird packet 1 payload
+        tx_weird_iter++;
+    }
+    // iter = 1514
+
+    asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
+
+    // read back/check weird packet 1 payload (bytes)
+    tx_weird_iter = 14;
+    while(tx_weird_iter < 1514)
+    {
+        if(tx_weird[tx_weird_iter] == (unsigned char)(0x55 + (tx_weird_iter - 14)) )
+        {
+            tx_weird_iter++;
+        }
+        else
+        {
+            break;
+        }
+    }
+/*
+    if(tx_weird_iter != 1514)
+    {
+        uint_to_string(tx_weird_iter, (unsigned char *)uint_string_array);
+        draw_string(30, 30, uint_string_array, STR_COLOR);
+        uint_to_string(tx_weird[tx_weird_iter], (unsigned char *)uint_string_array);
+        draw_string(130, 30, uint_string_array, STR_COLOR);
+    }
+*/
+
+    asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
+
+    unsigned int temp_sr = 0;
+    unsigned int temp_sr2 = 0;
+    asm volatile (
+        "stc SR, %[out]\n\t"
+        "mov %[out], %[out2]\n\t"
+        // preserve S and T
+        "and #0x0f, %[out2]\n\t"
+        // clear IMASK
+        "shlr8 %[out]\n\t"
+        "shll8 %[out]\n\t"
+        // Put S and T back
+        "or %[out], %[out2]\n\t"
+        // Store SR for later
+        "stc SR, %[out]\n\t"
+        // Enable external interrupts
+        "ldc %[out2], SR\n"
+    : [out] "=&r" (temp_sr), [out2] "=z" (temp_sr2) // outputs
+    : // inputs
+    : // clobbers
+    );
+
+    // Enable specific interrupts
+    g2_write_16(NIC(RT_INTRMASK), RT_INT_RXFIFO_OVERFLOW | RT_INT_RXBUF_OVERFLOW | RT_INT_RX_ERR | RT_INT_RX_OK);
+
+    asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
+
+    // Now do it again...
+    tx_weird_iter = 0;
+    while(tx_weird_iter < 6)
+    {
+        tx_weird[tx_weird_iter] = 0xff; // broadcast mac
+        tx_weird_iter++;
+    }
+    // iter = 6
+    memcpy(&tx_weird[6], adapter_bba.mac, 6); // bba's mac
+    tx_weird_iter += 6; // iter = 12
+    tx_weird[12] = 0xea; // ethertype
+    tx_weird[13] = 0x5; // err, this makes ethertype 0xea05, since network data is BE... Although LE 0x5ea is 1514--GAPS security thing?
+    tx_weird_iter += 2; // iter = 14
+    // Now for the last 1500 of weird packet 2
+    while(tx_weird_iter < 1514)
+    {
+        tx_weird[tx_weird_iter] = 0x5a + (tx_weird_iter - 14); // weird packet 2 payload
+        tx_weird_iter++;
+    }
+    // iter = 1514
+
+    asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
+
+    // read back/check weird packet 2 payload (words)
+    tx_weird_iter = 14;
+    while(tx_weird_iter < 1514)
+    {
+        if( ((unsigned short*)tx_weird)[tx_weird_iter/2] == ( (unsigned char)(0x5a + (tx_weird_iter - 14)) | ( (unsigned short)((unsigned char)(0x5a + (tx_weird_iter - 13))) << 8) ) )
+        {
+            tx_weird_iter += 2;
+        }
+        else
+        {
+            break;
+        }
+    }
+/*
+    if(tx_weird_iter != 1514) {
+        uint_to_string(tx_weird_iter, (unsigned char *)uint_string_array);
+        draw_string(230, 30, uint_string_array, STR_COLOR);
+        uint_to_string(tx_weird[tx_weird_iter], (unsigned char *)uint_string_array);
+        draw_string(330, 30, uint_string_array, STR_COLOR);
+    }
+*/
+
+    asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
+
+    // Disable interrupts because we don't want them
+    g2_write_16(NIC(RT_INTRMASK), 0);
+    // Restore SR
+    asm volatile ("ldc %[in], SR\n"
+    : // outputs
+    : [in] "r" (temp_sr) // inputs
+    : "t" // clobbers
+    );
+
+    asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
+}
+
 static void rtl_reset(void) {
     /* Soft-reset the chip */
     g2_write_8(NIC(RT_CHIPCMD), RT_CMD_RESET);
@@ -320,149 +551,11 @@ static void rtl_init(void) {
 
     /* Disable all interrupts */
     g2_write_16(NIC(RT_INTRMASK), 0);
-/*
-        //
-        // Very strange initialization stuff. Maybe getting this crazy init sequence right doubles the RX transfer
-        // speed, like how getting the GAPS memory-mapping registers right doubled the TX transfer speed? No idea.
-        // NOTE: Maybe these weird packets need to be sent via loopback mode?
-        // All this doesn't appear to be totally necessary--at least, things seem to work well without it. Wonder what it's for.
-        //
 
-        unsigned char *tx_weird = (unsigned char *)(0xa1840000 + 0x6000);
-        unsigned int tx_weird_iter = 0;
+    //weird_extra_init();
 
-        while(tx_weird_iter < 6)
-        {
-            tx_weird[tx_weird_iter] = 0xff; // broadcast mac
-            tx_weird_iter++;
-        }
-        // iter = 6
-        memcpy(&tx_weird[6], adapter_bba.mac, 6); // bba's mac
-        tx_weird_iter += 6; // iter = 12
-        tx_weird[12] = 0xea; // ethertype
-        tx_weird[13] = 0x5; // err, this makes ethertype 0xea05, since network data is BE... Although LE 0x5ea is 1514--GAPS security thing?
-        tx_weird_iter += 2; // iter = 14
-        // Now for the last 1500 of weird packet 1
-        while(tx_weird_iter < 1514)
-        {
-            tx_weird[tx_weird_iter] = 0x55 + (tx_weird_iter - 14); // weird packet 1 payload
-            tx_weird_iter++;
-        }
-        // iter = 1514
-
-        asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
-
-        // read back/check weird packet 1 payload (bytes)
-        tx_weird_iter = 14;
-        while(tx_weird_iter < 1514)
-        {
-            if(tx_weird[tx_weird_iter] == (unsigned char)(0x55 + (tx_weird_iter - 14)) )
-            {
-                tx_weird_iter++;
-            }
-            else
-            {
-                break;
-            }
-        }
-
-        if(tx_weird_iter != 1514)
-        {
-            uint_to_string(tx_weird_iter, (unsigned char *)uint_string_array);
-            draw_string(30, 30, uint_string_array, STR_COLOR);
-            uint_to_string(tx_weird[tx_weird_iter], (unsigned char *)uint_string_array);
-            draw_string(130, 30, uint_string_array, STR_COLOR);
-        }
-
-        asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
-
-        unsigned int temp_sr = 0;
-        unsigned int temp_sr2 = 0;
-        asm volatile (
-            "stc SR, %[out]\n\t"
-            "mov %[out], %[out2]\n\t"
-            // preserve S and T
-            "and #0x0f, %[out2]\n\t"
-            // clear IMASK
-            "shlr8 %[out]\n\t"
-            "shll8 %[out]\n\t"
-            // Put S and T back
-            "or %[out], %[out2]\n\t"
-            // Store SR for later
-            "stc SR, %[out]\n\t"
-            // Enable external interrupts
-            "ldc %[out2], SR\n"
-        : [out] "=&r" (temp_sr), [out2] "=z" (temp_sr2) // outputs
-        : // inputs
-        : // clobbers
-        );
-
-        // Enable specific interrupts
-        g2_write_16(NIC(RT_INTRMASK), RT_INT_RXFIFO_OVERFLOW | RT_INT_RXBUF_OVERFLOW | RT_INT_RX_ERR | RT_INT_RX_OK);
-
-        asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
-
-        // Now do it again...
-        tx_weird_iter = 0;
-        while(tx_weird_iter < 6)
-        {
-            tx_weird[tx_weird_iter] = 0xff; // broadcast mac
-            tx_weird_iter++;
-        }
-        // iter = 6
-        memcpy(&tx_weird[6], adapter_bba.mac, 6); // bba's mac
-        tx_weird_iter += 6; // iter = 12
-        tx_weird[12] = 0xea; // ethertype
-        tx_weird[13] = 0x5; // err, this makes ethertype 0xea05, since network data is BE... Although LE 0x5ea is 1514--GAPS security thing?
-        tx_weird_iter += 2; // iter = 14
-        // Now for the last 1500 of weird packet 2
-        while(tx_weird_iter < 1514)
-        {
-            tx_weird[tx_weird_iter] = 0x5a + (tx_weird_iter - 14); // weird packet 2 payload
-            tx_weird_iter++;
-        }
-        // iter = 1514
-
-        asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
-
-        // read back/check weird packet 2 payload (words)
-        tx_weird_iter = 14;
-        while(tx_weird_iter < 1514)
-        {
-            if( ((unsigned short*)tx_weird)[tx_weird_iter/2] == ( (unsigned char)(0x5a + (tx_weird_iter - 14)) | ( (unsigned short)((unsigned char)(0x5a + (tx_weird_iter - 13))) << 8) ) )
-            {
-                tx_weird_iter += 2;
-            }
-            else
-            {
-                break;
-            }
-        }
-
-        if(tx_weird_iter != 1514)
-        {
-            uint_to_string(tx_weird_iter, (unsigned char *)uint_string_array);
-            draw_string(230, 30, uint_string_array, STR_COLOR);
-            uint_to_string(tx_weird[tx_weird_iter], (unsigned char *)uint_string_array);
-            draw_string(330, 30, uint_string_array, STR_COLOR);
-        }
-
-        asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
-
-        // Disable interrupts because we don't want them
-        g2_write_16(NIC(RT_INTRMASK), 0);
-        // Restore SR
-        asm volatile ("ldc %[in], SR\n"
-        : // outputs
-        : [in] "r" (temp_sr) // inputs
-        : "t" // clobbers
-        );
-
-        asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
-*/
-
-// TODO tune twister seems like a useful thing
-// See https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/realtek/8139too.c#L1481
+    // TODO tune twister seems like a useful thing
+    // See https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/realtek/8139too.c#L1481
 
     /* Enable receive and transmit functions ... again*/
     g2_write_8(NIC(RT_CHIPCMD), RT_CMD_RX_ENABLE | RT_CMD_TX_ENABLE);
@@ -560,95 +653,11 @@ static int rtl_bb_tx(unsigned char *pkt, int len) {
 
     /* 8139 doesn't auto-pad */
     // This condition may look a little gnarly, but that's because it's meant for speed above all else.
+    /* All packets must be at least 60 bytes, pad them with null bytes if
+       they are not already of an appropriate size. */
     if(len < 60) {
-        // So pad it.
-        //
-        // We absolutely need to pad this, otherwise prior packets can leak into the
-        // padding. It's called "EtherLeak," and the RTL8139 is apparently a poster
-        // child chipset for the issues that come from lacking auto-pad.
-
-        unsigned int copyback_pkt_offset_len = 2 + len;
-        unsigned int copyback_pkt_len_align4 = copyback_pkt_offset_len & -4; // relative to copyback packet base
-        unsigned int copyback_pkt_extras = copyback_pkt_offset_len - copyback_pkt_len_align4;
-        unsigned int copyback_pkt_extras_end = (copyback_pkt_offset_len + 3) & -4; // This is either equal to or 4 bytes greater than copyback_pkt_len_align4
-
-        // Mix in trailing zeros if there are 1, 2, or 3 extra bytes
-        // Using 4-byte alignment for best performance.
-        if(copyback_pkt_extras) {
-            unsigned int last_data = 0x00000000;
-
-            // Need the 4-byte-aligned offset to store this padding-mixed data
-            unsigned int output_offset = copyback_pkt_len_align4;
-
-            last_data |= copyback_pkt_base[copyback_pkt_len_align4++]; // 1 extra byte
-
-            if(copyback_pkt_len_align4 != (unsigned int)copyback_pkt_offset_len) {
-                last_data |= (unsigned int)(copyback_pkt_base[copyback_pkt_len_align4++]) << 8; // 2 extra bytes
-            }
-
-            if(copyback_pkt_len_align4 != (unsigned int)copyback_pkt_offset_len) {
-                last_data |= (unsigned int)(copyback_pkt_base[copyback_pkt_len_align4]) << 16; // 3 extra bytes
-            }
-
-            // One 4-byte write instead of up to 3x 1-byte writes. For uncached setups, this makes odd-size
-            // small packets take the same total time to copy to the NIC as multiple-of-4-sized packets,
-            // meaning this is all running as fast as possible.
-            *(unsigned int *)(copyback_pkt_base + output_offset) = last_data;
-        }
-
-        // Pad the rest of the packet with zeros, if more trailing zeroes need to be written beyond the mixed bytes
-        // The only time this won't be true for small packets is for one with 17 payload bytes.
-        if(copyback_pkt_extras_end < 64) {
-            // 2 unmodified bytes will end up being written to the RTL's TX buffer (since we just want 60 bytes, which offsets
-            // to 62, and 62 then 4-byte-aligns to 64. Offset everything back 2 bytes to undo the internal ethernet alignment
-            // for transmit results in bytes 65-66 getting copied unzeroed), but that's OK here. The RTL8139C will clobber them
-            // with the second half of a 4-byte CRC because it's been configured to append a CRC, anyways--not to mention we set
-            // a length parameter for transmit, which makes those bytes doubly irrelevant.
-
-            unsigned int zero_remain = 64 - copyback_pkt_extras_end;
-            unsigned int zeroing_top = (unsigned int)copyback_pkt_base + copyback_pkt_extras_end + zero_remain; // add zero_remain for pre-dec
-            zero_remain /= 4; // will equal 1, 2, 3, 4, or 5
-            unsigned int zero_data = 0;
-
-            asm volatile (
-                "clrs\n" // Align for parallelism (CO) - SH4a use "stc SR, Rn" instead with a dummy Rn
-                "dt %[size]\n\t" // Decrement and test size here once to prevent extra jump (EX 1)
-            ".align 2\n"
-            "1:\n\t"
-                // *--nextd = val
-                "mov.l %[data], @-%[out]\n\t" // (LS 1/1)
-                "bf.s 1b\n\t" // (BR 1/2)
-                " dt %[size]\n\t" // (--size) ? 0 -> T : 1 -> T (EX 1)
-                : [out] "+r" (zeroing_top), [size] "+&r" (zero_remain) // outputs
-                : [data] "r" (zero_data) // inputs
-                : "t", "memory" // clobbers
-            );
-//
-// GCC does a mediocre job of optimizing memset on SH4 for some reason.
-// So, for reference, the above assembly just does this (except each loop takes only 2 cycles per iteration):
-//
-//          unsigned int zero_remain = (64 - copyback_pkt_extras_end) / 4;
-//          unsigned int * zeroing_base = (unsigned int*)(copyback_pkt_base + copyback_pkt_extras_end);
-//
-//          while(zero_remain--)
-//          {
-//              *zeroing_base++ = 0;
-//          }
-//
-// See DreamHAL for a complete set of similarly highly-optimized SH4 functions
-//
-        }
-
-        // Synchronize zeroed out data with tx buffer
-        // Note that 60 bytes would be offset by 62, still within 2nd cache block
-        // But we write to 64 bytes... which is still within the 2nd cache block ;).
-        CacheBlockWriteBack((unsigned char *)(copyback_pkt_base + 32), 1);
-
-        len = 60; // Finally, set length for transmit
-
-        // NOTE: The reason the minimum length is hardcoded to 60 is because the minimum
-        // frame size allowed is 46 bytes + 14 byte ethernet header. Well, it's actually 64,
-        // but the NIC is configured to auto-append a 4-byte CRC.
+        g2_memzero(copyback_pkt_base, len);
+        len = 60;
     }
 
     // Copy packet over to RTL via GAPS while also accounting for dcload-ip's packet alignment offset

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -65,7 +65,15 @@ static int rtl_bb_rx(void);
 
 #define RX_BUFFER_SHIFT         1 /* 0 : 8Kb, 1 : 16Kb, 2 : 32Kb, 3 : 64Kb */
 
+#define RX_CONFIG_DEFAULT       (RT_ERTH(0) | RT_RXC_RXFTH(2) | \
+                                RT_RXC_RBLEN(RX_BUFFER_SHIFT) | RT_RXC_MXDMA(1) | \
+                                RT_RXC_WRAP)
+
 #define RX_BUFFER_LEN           (0x2000 << RX_BUFFER_SHIFT)
+
+/* Set IFG to NOT violate 802.3 standard, 32 byte DMA burst */
+#define TX_MAX_DMA_BURST        1 /* 2^(4+n) bytes from 0-7 (16b - 2Kb) */
+#define TX_CONFIG               ((TX_MAX_DMA_BURST<<8) | 0x03000000)
 
 #define TX_BUFFER_OFFSET        (RX_BUFFER_LEN + 0x2000)
 #define TX_BUFFER_LEN           (0x800)
@@ -162,33 +170,37 @@ static void rtl_init(void)
 	// reset it AGAIN...
 	rtl_reset();
 
-	// Another dance of some kind...
-	nic8[RT_CHIPCMD] = RT_CMD_RX_ENABLE;
-	if(nic8[RT_CHIPCMD] == RT_CMD_RX_ENABLE)
-	{
-		nic8[RT_CHIPCMD] = RT_CMD_TX_ENABLE;
-		if(nic8[RT_CHIPCMD] == RT_CMD_TX_ENABLE)
-		{
-			nic8[RT_CHIPCMD] = 0; // Disable RX and TX now...
-		}
-	}
+    /* Perform some magic enable/disable dance */
+    g2_write_8(NIC(RT_CHIPCMD), RT_CMD_RX_ENABLE);
+
+    if(g2_read_8(NIC(RT_CHIPCMD)) == RT_CMD_RX_ENABLE) {
+        g2_write_8(NIC(RT_CHIPCMD), RT_CMD_TX_ENABLE);
+
+        if(g2_read_8(NIC(RT_CHIPCMD)) == RT_CMD_TX_ENABLE) {
+            /* Disable RX and TX */
+            g2_write_8(NIC(RT_CHIPCMD), 0);
+        }
+    }
 
 	asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
 
-	// Yet another dance of some kind...
-	nic32[RT_MAR0/4 + 0] = 0x55aaff00;
-	nic32[RT_MAR0/4 + 1] = 0xaa5500ff;
+    /* Now a dance with the Multicast Register before Enabling */
+    g2_write_32(NIC(RT_MAR0), 0x55aaff00);
+    g2_write_32(NIC(RT_MAR4), 0xaa5500ff);
 
-	if((nic32[RT_MAR0/4 + 0] == 0x55aaff00) && (nic32[RT_MAR0/4 + 1] == 0xaa5500ff))
-	{
-		nic8[RT_CHIPCMD] = RT_CMD_RX_ENABLE | RT_CMD_TX_ENABLE;
-		nic32[RT_MAR0/4 + 0] = 0xffffffff;
-		nic32[RT_MAR0/4 + 1] = 0xffffffff;
-	}
+    if((g2_read_32(NIC(RT_MAR0)) == 0x55aaff00) && 
+       (g2_read_32(NIC(RT_MAR4)) == 0xaa5500ff)) {
+        /* Enable receive and transmit functions */
+        g2_write_8(NIC(RT_CHIPCMD), RT_CMD_RX_ENABLE | RT_CMD_TX_ENABLE);
+
+        g2_write_32(NIC(RT_MAR0), 0xffffffff);
+        g2_write_32(NIC(RT_MAR4), 0xffffffff);
+    }
 
 	asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
 
-	nic16[RT_INTRMASK/2] = 0; // Disable interrupts
+    /* Disable all interrupts */
+    g2_write_16(NIC(RT_INTRMASK), 0);
 /*
 		//
 		// Very strange initialization stuff. Maybe getting this crazy init sequence right doubles the RX transfer
@@ -331,69 +343,61 @@ static void rtl_init(void)
 // TODO tune twister seems like a useful thing
 // See https://github.com/torvalds/linux/blob/master/drivers/net/ethernet/realtek/8139too.c#L1481
 
-	/* Enable receive and transmit functions */
-	nic8[RT_CHIPCMD] = RT_CMD_RX_ENABLE | RT_CMD_TX_ENABLE;
+    /* Enable receive and transmit functions ... again*/
+    g2_write_8(NIC(RT_CHIPCMD), RT_CMD_RX_ENABLE | RT_CMD_TX_ENABLE);
 
-	/* Set Rx FIFO threshold to 16 bytes, Rx size to 16k+16, 1024 byte DMA burst */
-//	nic32[RT_RXCONFIG/4] = 0x00000e00; // (1<<7 = 0x80) for nowrap or bit 7 = 0 for wrap, 1024 byte dma burst (6<<8 = 0x600)
-	// Why only 16k + 16? let's do 32k + 16.
-	nic32[RT_RXCONFIG/4] = 0x00004980; // nowrap, 16k + 16, 32 byte DMA burst, 64 byte Rx threshold, Early Rx: none
-//	nic32[RT_RXCONFIG/4] = 0x00002980; // nowrap, 16k + 16, 32 byte DMA burst, 32 byte Rx threshold, Early Rx: none
-//	nic32[RT_RXCONFIG/4] = 0x00005180; // nowrap, 32k + 16, 32 byte DMA burst, 64 byte Rx threshold, Early Rx: none
+    /* Set Rx FIFO threshold to 64 bytes, Rx size to 16k+16, 32 byte DMA burst */
+    g2_write_32(NIC(RT_RXCONFIG), RX_CONFIG_DEFAULT);
 
-//	nic32[RT_RXCONFIG/4] = 0x00005100; // wrap, 32k + 16, 32 byte DMA burst, 64 byte Rx threshold, Early Rx: none
-//	nic32[RT_RXCONFIG/4] = 0x00004900; // wrap, 16k + 16, 32 byte DMA burst, 64 byte Rx threshold, Early Rx: none
+    /* Set IFG to NOT violate 802.3 standard, 32 byte DMA burst */
+    g2_write_32(NIC(RT_TXCONFIG), TX_CONFIG);
 
-	/* Set Tx 1024 byte DMA burst */
-	// Found a bug: this was 00000600 before. 1024 byte DMA burst is 0x600 (hex), not 600 (dec).
-	// See pgs. 20-21 of RTL8139 datasheet: http://realtek.info/pdf/rtl8139cp.pdf
-//>	nic32[RT_TXCONFIG/4] = 0x03000600; // Set IFG to NOT violate 802.3 standard, 1024 byte DMA burst
-	nic32[RT_TXCONFIG/4] = 0x03000100; // Set IFG to NOT violate 802.3 standard, 32 byte DMA burst
-
-	/* Enable writing to the config registers */
-	nic8[RT_CFG9346] = 0xc0;
+    /* Enable writing to the config registers */
+    g2_write_8(NIC(RT_CFG9346), 0xc0);
 
 	/* Disable power management (zeroes are otherwise default values) */
 	// and 	/* Set the driver-loaded bit (0x20) */
 	// LEDs are apparently meant to be set to 0b10. Maybe those pins are repurposed?
-	nic8[RT_CONFIG1] = (nic8[RT_CONFIG1] | 0x80 | 0x20) & 0xbf;
+    g2_write_8(NIC(RT_CONFIG1), (g2_read_8(NIC(RT_CONFIG1)) & 
+        ~(RT_CONFIG1_LED0)) | RT_CONFIG1_DVRLOAD | RT_CONFIG1_LED1);
 
-	/* Enable FIFO auto-clear */
-	nic8[RT_CONFIG4] |= 0x80;
+    /* Enable FIFO auto-clear */
+    g2_write_8(NIC(RT_CONFIG4), g2_read_8(NIC(RT_CONFIG4)) | RT_CONFIG4_RxFIFIOAC);
 
 	// Make internal FIFO address pointer increment downwards
 	// This apparently can be set without unlocking the EEPROM,
 	// but might as well keep it here with the others.
-	nic8[RT_CONFIG5] |= 0x04;
+    /* Disable Link-Down Power Saver - this may have not been intended based on the previous comment*/
+    g2_write_8(NIC(RT_CONFIG5), g2_read_8(NIC(RT_CONFIG5)) | RT_CONFIG5_LDPS);
 
-	/* Switch back to normal operation mode */
-	nic8[RT_CFG9346] = 0;
+    /* Switch back to normal operation mode */
+    g2_write_8(NIC(RT_CFG9346), 0);
 
-	/* Filter out all multicast packets */
-	nic32[RT_MAR0/4 + 0] = 0;
-	nic32[RT_MAR0/4 + 1] = 0;
+    /* Filter out all multicast packets */
+    g2_write_32(NIC(RT_MAR0), 0);
+    g2_write_32(NIC(RT_MAR4), 0);
 
-	/* Disable all multi-interrupts */
-	nic16[RT_MULTIINTR/2] = 0;
+    /* Disable all multi-interrupts */
+    g2_write_16(NIC(RT_MULTIINTR), 0);
 
 	/* clear all interrupts */
-	nic16[RT_INTRSTATUS/2] = 0xffff;
+    g2_write_16(NIC(RT_INTRSTATUS), 0xffff);
 
-	/* Reset RXMISSED counter */
-	nic32[RT_RXMISSED/4] = 0;
+    /* Reset RXMISSED counter */
+    g2_write_32(NIC(RT_RXMISSED), 0);
 
-	/* Enable RX/TX once more */
-	nic8[RT_CHIPCMD] = RT_CMD_RX_ENABLE | RT_CMD_TX_ENABLE;
+    /* Enable RX/TX once more */
+    g2_write_8(NIC(RT_CHIPCMD), RT_CMD_RX_ENABLE | RT_CMD_TX_ENABLE);
 
-	/* Enable auto-negotiation and restart that process */
-	nic16[RT_MII_BMCR/2] |= 0x9200;
+    /* Reset, Enable, and start auto-negotiation */
+    g2_write_16(NIC(RT_MII_BMCR), RT_MII_RESET | RT_MII_AN_ENABLE | RT_MII_AN_START);
 
 	/* Initialize status vars */
 	rtl.cur_tx = 0;
 	rtl.cur_rx = 0;
 
-	/* Enable receiving broadcast and physical match packets */
-	nic32[RT_RXCONFIG/4] |= 0x0000000a;
+    /* Enable receiving broadcast and physical match packets */
+    g2_write_32(NIC(RT_RXCONFIG), g2_read_32(NIC(RT_RXCONFIG)) | RT_RXC_APM | RT_RXC_AB);
 }
 
 int rtl_bb_init(void)

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -15,19 +15,55 @@
 #include "memfuncs.h"
 #include "perfctr.h"
 
-// TEMP
-//#define LOOP_TIMING
+/* Performance Testing */
 //#define TX_LOOP_TIMING
 //#define RX_LOOP_TIMING
 //#define PKT_PROCESS_TIMING
 //#define FULL_TRIP_TIMING
 
-#ifdef LOOP_TIMING
-//#include "perfctr.h"
-#include "video.h"
-static char uint_string_array[11] = {0};
+#if defined(TX_LOOP_TIMING) || defined(FULL_TRIP_TIMING) || defined(RX_LOOP_TIMING) || defined(PKT_PROCESS_TIMING)
+    #include "video.h"
+    static char uint_string_array[11] = {0};
 #endif
-// end TEMP
+
+#define TIMING_START(var) uint64_t _##var = PMCR_RegRead(DCLOAD_PMCR);
+#define TIMING_PRINT(var, var2, line) uint64_t _##var2 = PMCR_RegRead(DCLOAD_PMCR); \
+                                    clear_lines(line, 24, global_bg_color); \
+                                    uint_to_string_dec((unsigned int)(_##var2 - _##var), (char*)uint_string_array); \
+                                    draw_string(30, line, uint_string_array, STR_COLOR);
+
+#ifdef TX_LOOP_TIMING
+    #define TX_LOOP_TIMING_START    TIMING_START(first_array)
+    #define TX_LOOP_TIMING_PRINT    TIMING_PRINT(first_array, second_array, 222)
+#else
+    #define TX_LOOP_TIMING_START
+    #define TX_LOOP_TIMING_PRINT
+#endif
+
+#ifdef FULL_TRIP_TIMING
+    #define FULL_TRIP_TIMING_START  TIMING_START(first_array1)
+    #define FULL_TRIP_TIMING_PRINT  TIMING_PRINT(first_array1, second_array1, 412)
+#else
+    #define FULL_TRIP_TIMING_START
+    #define FULL_TRIP_TIMING_PRINT
+#endif
+
+#ifdef RX_LOOP_TIMING
+    #define RX_LOOP_TIMING_START    TIMING_START(first_array)
+    #define RX_LOOP_TIMING_PRINT    TIMING_PRINT(first_array, second_array, 246)
+#else
+    #define RX_LOOP_TIMING_START
+    #define RX_LOOP_TIMING_PRINT
+#endif
+
+#ifdef PKT_PROCESS_TIMING
+    #define PKT_PROCESS_TIMING_START    asm volatile ("nop\n" : : : "memory"); \
+                                        TIMING_START(first_array2)
+    #define PKT_PROCESS_TIMING_PRINT    TIMING_PRINT(first_array2, second_array2, 270)
+#else
+    #define PKT_PROCESS_TIMING_START
+    #define PKT_PROCESS_TIMING_PRINT
+#endif
 
 static volatile unsigned char rtl_link_up = 0;
 static volatile unsigned char rtl_is_copying = 0;
@@ -512,10 +548,8 @@ static int rtl_bb_tx(unsigned char *pkt, int len) {
         }
     }
 
-// Tx time
-#ifdef TX_LOOP_TIMING
-    unsigned long long int first_array = PMCR_RegRead(DCLOAD_PMCR);
-#endif
+    // Tx time
+    TX_LOOP_TIMING_START
 
     unsigned char *copyback_pkt_base = to_p1(&pkt[-2]); // copyback base in cached memory area
 
@@ -621,15 +655,8 @@ static int rtl_bb_tx(unsigned char *pkt, int len) {
     SH4_mem_to_pkt_X_movca_32((unsigned char *)GAPS_DMA_AREA, copyback_pkt_base, len);
     // Technically this will prefetch beyond 1536 for packets between 1504 and 1514 in size, but that's not an issue.
 
-// Tx time end
-#ifdef TX_LOOP_TIMING
-    unsigned long long int second_array = PMCR_RegRead(DCLOAD_PMCR);
-    unsigned int loop_difference = (unsigned int)(second_array - first_array);
-
-    clear_lines(222, 24, global_bg_color);
-    uint_to_string_dec(loop_difference, (char*)uint_string_array);
-    draw_string(30, 222, uint_string_array, STR_COLOR);
-#endif
+    // Tx time end
+    TX_LOOP_TIMING_PRINT
 
     // Set len (SIZE field), destructively zeroing out all other R/W settings. OWN needs to be cleared by software; it does here.
     // Software writes don't impact the read-only bits.
@@ -696,50 +723,28 @@ static int rtl_bb_rx(void) {
 
         pkt_size = rx_size - 4;
 
-// Full loop timing
-#ifdef FULL_TRIP_TIMING
-        unsigned long long int first_array1 = PMCR_RegRead(DCLOAD_PMCR);
-#endif
+        // Full loop timing
+        FULL_TRIP_TIMING_START
 
         if((rx_status & 1) && (pkt_size <= RX_PKT_BUF_SIZE)) {
             pkt = (unsigned char *)(GAPS_RX_IO_AREA + 0x0000 + ring_offset + 4); // + 4 to skip the status byte (DMA)
 
-// Rx time
-#ifdef RX_LOOP_TIMING
-            unsigned long long int first_array = PMCR_RegRead(DCLOAD_PMCR);
-#endif
+            // Rx time
+            RX_LOOP_TIMING_START
 
             pktcpy(raw_current_pkt, pkt, pkt_size); // SH4_pkt_to_mem() will shift it by 2 for current_pkt
 
-// Rx time end
-#ifdef RX_LOOP_TIMING
-            unsigned long long int second_array = PMCR_RegRead(DCLOAD_PMCR);
-            unsigned int loop_difference = (unsigned int)(second_array - first_array);
+            // Rx time end
+            RX_LOOP_TIMING_PRINT
 
-            clear_lines(246, 24, global_bg_color);
-            uint_to_string_dec(loop_difference, (char *)uint_string_array);
-            draw_string(30, 246, uint_string_array, STR_COLOR);
-#endif
-
-// Process time
-#ifdef PKT_PROCESS_TIMING
-            asm volatile ("nop\n" : : : "memory");
-            unsigned long long int  first_array2 = PMCR_RegRead(DCLOAD_PMCR);
-#endif
+            // Process time
+            PKT_PROCESS_TIMING_START
 
             //process_pkt(current_pkt);
             process_pkt(to_p1(current_pkt));
 
-// Process time end
-#ifdef PKT_PROCESS_TIMING
-            unsigned long long int second_array2 = PMCR_RegRead(DCLOAD_PMCR);
-            unsigned int loop_difference2 = (unsigned int)(second_array2 - first_array2);
-
-            clear_lines(270, 24, global_bg_color);
-            uint_to_string_dec(loop_difference2, (char *)uint_string_array);
-            draw_string(30, 270, uint_string_array, STR_COLOR);
-#endif
-
+            // Process time end
+            PKT_PROCESS_TIMING_PRINT
         }
 
         // Align next packet to 4-bytes (add 4 to account for transmit status; the 4 extra bytes included in rx_size are the CRC)
@@ -779,14 +784,7 @@ static int rtl_bb_rx(void) {
 
         processed++;
 
-#ifdef FULL_TRIP_TIMING
-        unsigned long long int second_array1 = PMCR_RegRead(DCLOAD_PMCR);
-        unsigned int loop_difference1 = (unsigned int)(second_array1 - first_array1);
-
-        clear_lines(412, 24, global_bg_color);
-        uint_to_string_dec(loop_difference1, (char *)uint_string_array);
-        draw_string(30, 412, uint_string_array, STR_COLOR);
-#endif
+        FULL_TRIP_TIMING_PRINT
     }
 
     return processed;

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -614,6 +614,19 @@ static void rtl_init(void) {
     g2_write_32(NIC(RT_RXCONFIG), g2_read_32(NIC(RT_RXCONFIG)) | RT_RXC_APM | RT_RXC_AB);
 }
 
+static void rx_reset(void) {
+    rtl.cur_rx = g2_read_16(NIC(RT_RXBUFHEAD));
+    g2_write_16(NIC(RT_RXBUFTAIL), rtl.cur_rx - 16);
+
+    rtl.cur_rx = 0;
+    g2_write_8(NIC(RT_CHIPCMD), RT_CMD_TX_ENABLE);
+
+    while(!(g2_read_8(NIC(RT_CHIPCMD)) & RT_CMD_RX_ENABLE))
+        g2_write_8(NIC(RT_CHIPCMD), RT_CMD_TX_ENABLE | RT_CMD_RX_ENABLE);
+
+    g2_write_32(NIC(RT_RXCONFIG), RX_CONFIG_DEFAULT | RT_RXC_APM | RT_RXC_AB);
+    g2_write_16(NIC(RT_INTRSTATUS), 0xffff);
+}
 
 static void rtl_bb_start(void) {
     g2_write_32(NIC(RT_RXCONFIG), g2_read_32(NIC(RT_RXCONFIG)) | (RT_RXC_APM | RT_RXC_AB));
@@ -786,10 +799,8 @@ static void bba_rx(void) {
         if(intr & RT_INT_RX_ACK)
             g2_write_16(NIC(RT_INTRSTATUS), RT_INT_RX_ACK);
 
-
         FULL_TRIP_TIMING_PRINT
     }
-
 }
 
 static void rtl_bb_loop(int is_main_loop) {
@@ -866,26 +877,8 @@ static void rtl_bb_loop(int is_main_loop) {
 
         /* Rx Buffer overflow */
         if(intr & RT_INT_RXBUF_OVERFLOW) {
-/*
-            // Update CAPR
-            rtl.cur_rx = g2_read_16(NIC(RT_RXBUFHEAD));
-            g2_write_16(NIC(RT_RXBUFTAIL), rtl.cur_rx - 16);
-            rtl.cur_rx = 0;
-
-            // Disable receive
-            g2_write_8(NIC(RT_CHIPCMD), RT_CMD_TX_ENABLE);
-
-            // Wait for it
-            while( !(g2_read_8(NIC(RT_CHIPCMD)) & RT_CMD_RX_ENABLE))
-                g2_write_8(NIC(RT_CHIPCMD), RT_CMD_TX_ENABLE | RT_CMD_RX_ENABLE); // Weirdly, keep spamming re-enable receive
-
-            // Re-set RXCONFIG
-            g2_write_32(NIC(RT_RXCONFIG), 0x0000f60a); // This should be whatever is set in init plus enabling packet reception (| 0x...a)
-
-            // clear interrupts
-            g2_write_16(NIC(RT_INTRSTATUS), 0xffff);
-    */
             // NetBSD, FreeBSD, and OpenBSD all just do a full re-init if this happens.
+            //rx_reset();
             rtl_init();
         }
 

--- a/target-src/dcload/rtl8139.c
+++ b/target-src/dcload/rtl8139.c
@@ -35,7 +35,7 @@ adapter_t adapter_bba = {
     { 0 },      // Mac address
     { 0 },      // 2-byte alignment pad
     gaps_detect,
-    rtl_bb_init,
+    gaps_init,
     rtl_bb_start,
     rtl_bb_stop,
     rtl_bb_loop,
@@ -51,6 +51,8 @@ static void rtl_init(void);
 static void pktcpy(unsigned char *dest, unsigned char *src, unsigned int n);
 static int rtl_bb_rx(void);
 
+/* KOS API shim definitions */
+
 #define g2_write_8(address, value) *((volatile uint8_t *)(address)) = (value)
 #define g2_write_16(address, value) *((volatile uint16_t *)(address)) = (value)
 #define g2_write_32(address, value) *((volatile uint32_t *)(address)) = (value)
@@ -60,6 +62,8 @@ static int rtl_bb_rx(void);
 
 #define MEM_AREA_P1_BASE        (0x80000000)
 #define MEM_AREA_P2_BASE        (0xa0000000)
+
+/* Configuration definitions */
 
 #define RTL_MEM                 (0x01840000)
 
@@ -79,27 +83,9 @@ static int rtl_bb_rx(void);
 #define TX_BUFFER_LEN           (0x800)
 #define TX_NB_BUFFERS           4
 
+/****************************************************************************/
+/* GAPS PCI stuff probably ought to be moved to another file... */
 #define GAPS_BASE               (0x01000000 | MEM_AREA_P2_BASE)
-
-/* 8, 16, and 32 bit access to the PCI I/O space (configured by GAPS) */
-#define NIC(ADDR) (GAPS_BASE + 0x1700 + (ADDR))
-
-/* 8, 16, and 32 bit access to the PCI MEMMAP space (configured by GAPS) */
-static uint32_t const rtl_mem = MEM_AREA_P2_BASE + RTL_MEM;
-
-#define GAPS_RX_IO_AREA (RTL_MEM | MEM_AREA_P1_BASE)
-#define GAPS_TX_IO_AREA (RTL_MEM | MEM_AREA_P1_BASE)
-
-/* TX buffer pointers */
-static vuc *const txdesc[TX_NB_BUFFERS] = {
-    REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 0)),
-    REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 1)),
-    REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 2)),
-    REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 3))
-};
-
-#define GAPS_DMA_AREA (GAPS_RX_IO_AREA | 0x8000)
-
 
 /* Detect a GAPS PCI bridge */
 int gaps_detect(void) {
@@ -119,6 +105,113 @@ int gaps_detect(void) {
     else
         return -1;
 }
+
+/* Initialize GAPS PCI bridge */
+int gaps_init(void) {
+    int i;
+
+    // The BBA uses the range 0x01840000-0x0184ffff for TX and RX (with usage above
+    // 0x01848000 apparently for GAPS DMA), plus the 2 bytes at 0x0183fffc for... something
+
+    /* Initialize the "GAPS" PCI glue controller. */
+    // NOTE: Setting 0x5a14a500 turns off GAPS.
+    g2_write_32(GAPS_BASE + 0x1418, 0x5a14a501);    /* M */
+    i = 10000;
+    // This delay is probably the part where the RealTek 8139C datasheet says to
+    // wait 2ms for the chip to powerup and load its config from its EEPROM
+    while(!(g2_read_32(GAPS_BASE + 0x1418) & 1) && i > 0)
+        i--;
+
+    /* timed out waiting for rtl8139c to init */
+    if(!(g2_read_32(GAPS_BASE + 0x1418) & 1)) {
+        return -1;
+    }
+
+    g2_write_32(GAPS_BASE + 0x1420, 0x01000000);
+    g2_write_32(GAPS_BASE + 0x1424, 0x01000000);
+    g2_write_32(GAPS_BASE + 0x1428, RTL_MEM);       /* DMA Base */
+    /* Register offset 0x142c controls where the image area at GAPS offset 0x8000 (so 0x01848000) points to, which is used by DMA */
+    g2_write_32(GAPS_BASE + 0x1414, 0x00000001); // Interrupt-related...? (Whatever this is, it gets 1 written to it a couple times, and gets a zero written to it in the same places where 0x1418 gets the turn-off code...)
+    g2_write_32(GAPS_BASE + 0x1434, 0x00000001);
+
+    // There appears to be a register at offset 0x1410, which has 0x0c003000 in it. This appears to be a pretty random address in the syscall area.
+    // It doesn't seem to be used for anything, though, and it just seems to get read from in its unused function--it's never written to.
+    // Similarly, 0x1430 has 0x00000010 in it, who knows what for. This one doesn't even have an unused function for it.
+
+    // Now configure the RTL8139's PCI configuration
+
+    // VEN:DEV is 11db:1234 (vendor code is "Sega Enterprises, LTD")
+    // The GAPS bridge is really just an MMU with a memory buffer that maps the RTL8139C to the Dreamcast's memory space,
+    // so these are actually the PCI configuration registers for the RTL8139, not GAPS (those are just the 0x1400 regs).
+    // It has a custom ven:dev ID, but the class ID in 0x1608 indicates a network controller (byte 0x160b = 0x02 = network controller, 0x160a = 0x00 = Ethernet controller)
+    // See PCI Local Bus Specification 2.2 (2.3 has all the 2.2 stuff in it and the RTL8139C uses 2.2)
+    // This is also documented in the RTL8139C's datasheet, under "PCI Configuration Space Registers"
+    g2_write_16(GAPS_BASE + 0x1606, 0xf900);     /* PCI Status Register */
+    g2_write_32(GAPS_BASE + 0x1630, 0x00000000); /* PCI BMAR */
+    g2_write_8(GAPS_BASE + 0x163c, 0x00);        /* Interrupt Line */
+    g2_write_8(GAPS_BASE + 0x160d, 0xf0);        /* Primary Latency Timer */
+
+    /* PCI Command Register (Fast Back-to-Back is read-only 0 on this bridge)
+       0x1610 (BAR0, I/O BAR) reads back as 0x00000001, which is I/O Space Indicator
+    */
+    g2_write_16(GAPS_BASE + 0x1604, g2_read_16(GAPS_BASE + 0x1604) | 0x6);
+
+    g2_write_32(GAPS_BASE + 0x1614, 0x01000000); /* BAR1 (Memory BAR) */
+
+    /* There are two extra regs here that are GAPS-specific (0x1650 and 0x1654). */
+    if(g2_read_8(GAPS_BASE + 0x1650) & 0x1) {
+        g2_write_16(GAPS_BASE + 0x1654, (g2_read_16(GAPS_BASE + 0x1654) & 0xfffc) | 0x8000);
+    }
+
+    /* Apparently we do this again */
+    g2_write_32(GAPS_BASE + 0x1414, 0x00000001); /* Interrupt enable */
+
+    /* Clear GAPS mem */
+    memset_zeroes_64bit((void *)RTL_MEM, 32768/8);
+    CacheBlockPurge((void *)RTL_MEM, 32768/32); // Write back and invalidate the cache over that area since it's volatile
+
+    /* Another magic number sequence, possibly checking previous init. */
+    /* ASCII for 'SEGA' in little-endian */
+    if(g2_read_32(GAPS_BASE + 0x141c) == 0x41474553) {
+        g2_write_32(GAPS_BASE + 0x141c, 0x55aaff00);
+
+        if(g2_read_32(GAPS_BASE + 0x141c) == 0x55aaff00) {
+            g2_write_32(GAPS_BASE + 0x141c, 0xaa5500ff);
+
+            if(g2_read_32(GAPS_BASE + 0x141c) == 0xaa5500ff) {
+                g2_write_32(GAPS_BASE + 0x141c, 0x41474553);
+                /* I think GAPS automatically pulls RSTB low for 120ns, which
+                   causes the EEPROM to autoload all the registers initially.
+                   So we don't need to worry about it.
+                */
+                rtl_init();
+                return 0;
+            }
+        }
+    }
+
+    return -3;
+}
+
+
+/* 8, 16, and 32 bit access to the PCI I/O space (configured by GAPS) */
+#define NIC(ADDR) (GAPS_BASE + 0x1700 + (ADDR))
+
+/* 8, 16, and 32 bit access to the PCI MEMMAP space (configured by GAPS) */
+static uint32_t const rtl_mem = MEM_AREA_P2_BASE + RTL_MEM;
+
+#define GAPS_RX_IO_AREA (RTL_MEM | MEM_AREA_P1_BASE)
+#define GAPS_TX_IO_AREA (RTL_MEM | MEM_AREA_P1_BASE)
+
+/* TX buffer pointers */
+static vuc *const txdesc[TX_NB_BUFFERS] = {
+    REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 0)),
+    REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 1)),
+    REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 2)),
+    REGC(GAPS_TX_IO_AREA + TX_BUFFER_OFFSET + (TX_BUFFER_LEN * 3))
+};
+
+#define GAPS_DMA_AREA (GAPS_RX_IO_AREA | 0x8000)
 
 static void rtl_reset(void) {
     /* Soft-reset the chip */
@@ -150,9 +243,8 @@ static void rtl_init(void) {
     g2_write_32(NIC(RT_RXBUF), RTL_MEM);
 
     /* Setup TX buffers */
-    for(tmp=0; tmp<TX_NB_BUFFERS; tmp++) {
+    for(tmp=0; tmp<TX_NB_BUFFERS; tmp++)
         g2_write_32(NIC(RT_TXADDR0 + (tmp * 4)), RTL_MEM + (tmp * TX_BUFFER_LEN) + TX_BUFFER_OFFSET);
-    }
 
     asm volatile ("nop\n" : : : "memory"); // Compiler barrier so that GCC doesn't get clever here
 
@@ -392,91 +484,6 @@ static void rtl_init(void) {
     g2_write_32(NIC(RT_RXCONFIG), g2_read_32(NIC(RT_RXCONFIG)) | RT_RXC_APM | RT_RXC_AB);
 }
 
-int rtl_bb_init(void) {
-    int i;
-
-    // The BBA uses the range 0x01840000-0x0184ffff for TX and RX (with usage above
-    // 0x01848000 apparently for GAPS DMA), plus the 2 bytes at 0x0183fffc for... something
-
-    /* Initialize the "GAPS" PCI glue controller. */
-    // NOTE: Setting 0x5a14a500 turns off GAPS.
-    g2_write_32(GAPS_BASE + 0x1418, 0x5a14a501);    /* M */
-    i = 10000;
-    // This delay is probably the part where the RealTek 8139C datasheet says to
-    // wait 2ms for the chip to powerup and load its config from its EEPROM
-    while(!(g2_read_32(GAPS_BASE + 0x1418) & 1) && i > 0)
-        i--;
-
-    /* timed out waiting for rtl8139c to init */
-    if(!(g2_read_32(GAPS_BASE + 0x1418) & 1)) {
-        return -1;
-    }
-
-    g2_write_32(GAPS_BASE + 0x1420, 0x01000000);
-    g2_write_32(GAPS_BASE + 0x1424, 0x01000000);
-    g2_write_32(GAPS_BASE + 0x1428, RTL_MEM);       /* DMA Base */
-    /* Register offset 0x142c controls where the image area at GAPS offset 0x8000 (so 0x01848000) points to, which is used by DMA */
-    g2_write_32(GAPS_BASE + 0x1414, 0x00000001); // Interrupt-related...? (Whatever this is, it gets 1 written to it a couple times, and gets a zero written to it in the same places where 0x1418 gets the turn-off code...)
-    g2_write_32(GAPS_BASE + 0x1434, 0x00000001);
-
-    // There appears to be a register at offset 0x1410, which has 0x0c003000 in it. This appears to be a pretty random address in the syscall area.
-    // It doesn't seem to be used for anything, though, and it just seems to get read from in its unused function--it's never written to.
-    // Similarly, 0x1430 has 0x00000010 in it, who knows what for. This one doesn't even have an unused function for it.
-
-    // Now configure the RTL8139's PCI configuration
-
-    // VEN:DEV is 11db:1234 (vendor code is "Sega Enterprises, LTD")
-    // The GAPS bridge is really just an MMU with a memory buffer that maps the RTL8139C to the Dreamcast's memory space,
-    // so these are actually the PCI configuration registers for the RTL8139, not GAPS (those are just the 0x1400 regs).
-    // It has a custom ven:dev ID, but the class ID in 0x1608 indicates a network controller (byte 0x160b = 0x02 = network controller, 0x160a = 0x00 = Ethernet controller)
-    // See PCI Local Bus Specification 2.2 (2.3 has all the 2.2 stuff in it and the RTL8139C uses 2.2)
-    // This is also documented in the RTL8139C's datasheet, under "PCI Configuration Space Registers"
-    g2_write_16(GAPS_BASE + 0x1606, 0xf900);     /* PCI Status Register */
-    g2_write_32(GAPS_BASE + 0x1630, 0x00000000); /* PCI BMAR */
-    g2_write_8(GAPS_BASE + 0x163c, 0x00);        /* Interrupt Line */
-    g2_write_8(GAPS_BASE + 0x160d, 0xf0);        /* Primary Latency Timer */
-
-    /* PCI Command Register (Fast Back-to-Back is read-only 0 on this bridge)
-       0x1610 (BAR0, I/O BAR) reads back as 0x00000001, which is I/O Space Indicator
-    */
-    g2_write_16(GAPS_BASE + 0x1604, g2_read_16(GAPS_BASE + 0x1604) | 0x6);
-
-    g2_write_32(GAPS_BASE + 0x1614, 0x01000000); /* BAR1 (Memory BAR) */
-
-    /* There are two extra regs here that are GAPS-specific (0x1650 and 0x1654). */
-    if(g2_read_8(GAPS_BASE + 0x1650) & 0x1) {
-        g2_write_16(GAPS_BASE + 0x1654, (g2_read_16(GAPS_BASE + 0x1654) & 0xfffc) | 0x8000);
-    }
-
-    /* Apparently we do this again */
-    g2_write_32(GAPS_BASE + 0x1414, 0x00000001); /* Interrupt enable */
-
-    /* Clear GAPS mem */
-    memset_zeroes_64bit((void *)RTL_MEM, 32768/8);
-    CacheBlockPurge((void *)RTL_MEM, 32768/32); // Write back and invalidate the cache over that area since it's volatile
-
-    /* Another magic number sequence, possibly checking previous init. */
-    /* ASCII for 'SEGA' in little-endian */
-    if(g2_read_32(GAPS_BASE + 0x141c) == 0x41474553) {
-        g2_write_32(GAPS_BASE + 0x141c, 0x55aaff00);
-
-        if(g2_read_32(GAPS_BASE + 0x141c) == 0x55aaff00) {
-            g2_write_32(GAPS_BASE + 0x141c, 0xaa5500ff);
-
-            if(g2_read_32(GAPS_BASE + 0x141c) == 0xaa5500ff) {
-                g2_write_32(GAPS_BASE + 0x141c, 0x41474553);
-                /* I think GAPS automatically pulls RSTB low for 120ns, which
-                   causes the EEPROM to autoload all the registers initially.
-                   So we don't need to worry about it.
-                */
-                rtl_init();
-                return 0;
-            }
-        }
-    }
-
-    return -3;
-}
 
 void rtl_bb_start(void) {
     g2_write_32(NIC(RT_RXCONFIG), g2_read_32(NIC(RT_RXCONFIG)) | (RT_RXC_APM | RT_RXC_AB));

--- a/target-src/dcload/rtl8139.h
+++ b/target-src/dcload/rtl8139.h
@@ -259,11 +259,6 @@
 #define REGC(a) (volatile unsigned char *)(a)
 #define vuc volatile unsigned char
 
-/* Configuration definitions */
-// RTL8139 RX buffer size.
-#define RX_BUFFER_LEN        16384U
-//#define RX_BUFFER_LEN        32768U
-
 #define GAPSPCI_ID "GAPSPCI_BRIDGE_2"
 
 /* RTL8139C Config/Status info */

--- a/target-src/dcload/rtl8139.h
+++ b/target-src/dcload/rtl8139.h
@@ -259,13 +259,4 @@
 #define REGC(a) (volatile unsigned char *)(a)
 #define vuc volatile unsigned char
 
-#define GAPSPCI_ID "GAPSPCI_BRIDGE_2"
-
-/* RTL8139C Config/Status info */
-typedef struct {
-	unsigned short cur_rx;                /* Current Rx read ptr */
-	unsigned short cur_tx;                /* Current available Tx slot */
-	unsigned char  mac[6];                /* Mac address */
-} rtl_status_t;
-
 #endif

--- a/target-src/dcload/rtl8139.h
+++ b/target-src/dcload/rtl8139.h
@@ -1,80 +1,255 @@
 #ifndef __RTL8139_H__
 #define __RTL8139_H__
 
-/* RTL8139C register definitions */
-#define RT_IDR0                0x00       /* Mac address */
-#define RT_MAR0                0x08       /* Multicast filter */
-#define RT_TXSTATUS0           0x10       /* Transmit status (4 32bit regs) */
-#define RT_TXADDR0             0x20       /* Tx descriptors (also 4 32bit) */
-#define RT_RXBUF               0x30       /* Receive buffer start address */
-#define RT_RXEARLYCNT          0x34       /* Early Rx byte count */
-#define RT_RXEARLYSTATUS       0x36       /* Early Rx status */
-#define RT_CHIPCMD             0x37       /* Command register */
-#define RT_RXBUFTAIL           0x38       /* Current address of packet read (queue tail) */
-#define RT_RXBUFHEAD           0x3A       /* Current buffer address (queue head) */
-#define RT_INTRMASK            0x3C       /* Interrupt mask */
-#define RT_INTRSTATUS          0x3E       /* Interrupt status */
-#define RT_TXCONFIG            0x40       /* Tx config */
-#define RT_RXCONFIG            0x44       /* Rx config */
-#define RT_TIMER               0x48       /* A general purpose counter */
-#define RT_RXMISSED            0x4C       /* 24 bits valid, write clears */
-#define RT_CFG9346             0x50       /* 93C46 command register */
-#define RT_CONFIG0             0x51       /* Configuration reg 0 */
-#define RT_CONFIG1             0x52       /* Configuration reg 1 */
-#define RT_TIMERINT            0x54       /* Timer interrupt register (32 bits) */
-#define RT_MEDIASTATUS         0x58       /* Media status register */
-#define RT_CONFIG3             0x59       /* Config register 3 */
-#define RT_CONFIG4             0x5A       /* Config register 4 */
-#define RT_MULTIINTR           0x5C       /* Multiple interrupt select */
-#define RT_MII_TSAD            0x60       /* Transmit status of all descriptors (16 bits) */
-#define RT_MII_BMCR            0x62       /* Basic Mode Control Register (16 bits) */
-#define RT_MII_BMSR            0x64       /* Basic Mode Status Register (16 bits) */
-#define RT_AS_ADVERT           0x66       /* Auto-negotiation advertisement reg (16 bits) */
-#define RT_AS_LPAR             0x68       /* Auto-negotiation link partner reg (16 bits) */
-#define RT_AS_EXPANSION        0x6A       /* Auto-negotiation expansion reg (16 bits) */
-// There are many more...
-#define RT_CONFIG5             0xD8       /* Config register 5 */
+/** \defgroup bba Broadband Adapter
+    \brief    Driver for the Dreamcast's BBA (RTL8139C).
+    \ingroup  networking_drivers
+    @{
+*/
 
-/* RTL8193C command bits; or these together and write teh resulting value
-   into CHIPCMD to execute it. */
-#define RT_CMD_RESET           0x10
-#define RT_CMD_RX_ENABLE       0x08
-#define RT_CMD_TX_ENABLE       0x04
-#define RT_CMD_RX_BUF_EMPTY    0x01
+/** \defgroup bba_regs Registers
+    \brief    Registers and related info for the broadband adapter
+    @{
+*/
 
-/* RTL8139C interrupt status bits */
-#define RT_INT_PCIERR          0x8000     /* PCI Bus error */
-#define RT_INT_TIMEOUT         0x4000     /* Set when TCTR reaches TimerInt value */
-#define RT_INT_RXFIFO_OVERFLOW 0x0040     /* Rx FIFO overflow */
-#define RT_INT_RXFIFO_UNDERRUN 0x0020     /* Packet underrun / link change */
-#define RT_INT_RXBUF_OVERFLOW  0x0010     /* Rx BUFFER overflow */
-#define RT_INT_TX_ERR          0x0008
-#define RT_INT_TX_OK           0x0004
-#define RT_INT_RX_ERR          0x0002
-#define RT_INT_RX_OK           0x0001
+/** \defgroup bba_regs_locs Locations
+    \brief    Locations for various broadband adapter registers.
 
-/* Composite RX bits we check for while doing an RX interrupt */
+    The default assumption is that these are all RW at any aligned size unless
+    otherwise noted. ex (RW 32bit, RO 16/8) indicates read/write at 32bit and
+    read-only at 16 or 8bits.
+
+    @{
+*/
+#define RT_IDR0             0x00    /**< \brief MAC address 0 (RW 32bit, RO 16/8) */
+#define RT_IDR1             0x01    /**< \brief MAC address 1 (Read-only) */
+#define RT_IDR2             0x02    /**< \brief MAC address 2 (Read-only) */
+#define RT_IDR3             0x03    /**< \brief MAC address 3 (Read-only) */
+#define RT_IDR4             0x04    /**< \brief MAC address 4 (RW 32bit, RO 16/8) */
+#define RT_IDR5             0x05    /**< \brief MAC address 5 (Read-only) */
+#define RT_RES06            0x06    /**< \brief Reserved */
+#define RT_RES07            0x07    /**< \brief Reserved */
+#define RT_MAR0             0x08    /**< \brief Multicast filter 0 (RW 32bit, RO 16/8) */
+#define RT_MAR1             0x09    /**< \brief Multicast filter 1 (Read-only) */
+#define RT_MAR2             0x0A    /**< \brief Multicast filter 2 (Read-only) */
+#define RT_MAR3             0x0B    /**< \brief Multicast filter 3 (Read-only) */
+#define RT_MAR4             0x0C    /**< \brief Multicast filter 4 (RW 32bit, RO 16/8) */
+#define RT_MAR5             0x0D    /**< \brief Multicast filter 5 (Read-only) */
+#define RT_MAR6             0x0E    /**< \brief Multicast filter 6 (Read-only) */
+#define RT_MAR7             0x0F    /**< \brief Multicast filter 7 (Read-only) */
+#define RT_TXSTATUS0        0x10    /**< \brief Transmit status 0 (32bit only) */
+#define RT_TXSTATUS1        0x14    /**< \brief Transmit status 1 (32bit only) */
+#define RT_TXSTATUS2        0x18    /**< \brief Transmit status 2 (32bit only) */
+#define RT_TXSTATUS3        0x1C    /**< \brief Transmit status 3 (32bit only) */
+#define RT_TXADDR0          0x20    /**< \brief Tx descriptor 0 (32bit only) */
+#define RT_TXADDR1          0x24    /**< \brief Tx descriptor 1 (32bit only) */
+#define RT_TXADDR2          0x28    /**< \brief Tx descriptor 2 (32bit only) */
+#define RT_TXADDR3          0x2C    /**< \brief Tx descriptor 3 (32bit only) */
+#define RT_RXBUF            0x30    /**< \brief Receive buffer start address (32bit only) */
+#define RT_RXEARLYCNT       0x34    /**< \brief Early Rx byte count (RO 16bit) */
+#define RT_RXEARLYSTATUS    0x36    /**< \brief Early Rx status (RO) */
+#define RT_CHIPCMD          0x37    /**< \brief Command register */
+#define RT_RXBUFTAIL        0x38    /**< \brief Current address of packet read (queue tail) (16bit only) */
+#define RT_RXBUFHEAD        0x3A    /**< \brief Current buffer address (queue head) (RO 16bit) */
+#define RT_INTRMASK         0x3C    /**< \brief Interrupt mask (16bit only) */
+#define RT_INTRSTATUS       0x3E    /**< \brief Interrupt status (16bit only) */
+#define RT_TXCONFIG         0x40    /**< \brief Tx config (32bit only) */
+#define RT_RXCONFIG         0x44    /**< \brief Rx config (32bit only) */
+#define RT_TIMER            0x48    /**< \brief A general purpose counter, any write clears (32bit only) */
+#define RT_RXMISSED         0x4C    /**< \brief 24 bits valid, write clears (32bit only) */
+#define RT_CFG9346          0x50    /**< \brief 93C46 command register */
+#define RT_CONFIG0          0x51    /**< \brief Configuration reg 0 */
+#define RT_CONFIG1          0x52    /**< \brief Configuration reg 1 */
+#define RT_RES53            0x53    /**< \brief Reserved */
+#define RT_TIMERINT         0x54    /**< \brief Timer interrupt register (32bit only) */
+#define RT_MEDIASTATUS      0x58    /**< \brief Media status register */
+#define RT_CONFIG3          0x59    /**< \brief Config register 3 */
+#define RT_CONFIG4          0x5A    /**< \brief Config register 4 */
+#define RT_RES5B            0x5B    /**< \brief Reserved */
+#define RT_MULTIINTR        0x5C    /**< \brief Multiple interrupt select (32bit only) */
+#define RT_RERID            0x5E    /**< \brief PCI Revision ID (10h) (Read-only) */
+#define RT_RES5F            0x5F    /**< \brief Reserved */
+#define RT_MII_TSAD         0x60    /**< \brief Transmit status of all descriptors (RO 16bit) */
+#define RT_MII_BMCR         0x62    /**< \brief Basic Mode Control Register (16bit only) */
+#define RT_MII_BMSR         0x64    /**< \brief Basic Mode Status Register (RO 16bit) */
+#define RT_AS_ADVERT        0x66    /**< \brief Auto-negotiation advertisement reg (16bit only) */
+#define RT_AS_LPAR          0x68    /**< \brief Auto-negotiation link partner reg (RO 16bit) */
+#define RT_AS_EXPANSION     0x6A    /**< \brief Auto-negotiation expansion reg (RO 16bit) */
+
+#define RT_CONFIG5          0xD8    /**< \brief Config register 5 */
+/** @} */
+
+/** \defgroup bba_regs_fields Fields
+    \brief    Register fields for the broadband adapter
+    @{
+*/
+
+/** \defgroup bba_miicb MII Control Bits
+    \brief    BBA media independent interface control register fields
+    @{
+*/
+#define RT_MII_RESET       0x8000  /**< \brief Reset the MII chip */
+#define RT_MII_RES4000     0x4000  /**< \brief Reserved */
+#define RT_MII_SPD_SET     0x2000  /**< \brief 1 for 100 0 for 10. Ignored if AN enabled. */
+#define RT_MII_AN_ENABLE   0x1000  /**< \brief Enable auto-negotiation */
+#define RT_MII_RES0800     0x0800  /**< \brief Reserved */
+#define RT_MII_RES0400     0x0400  /**< \brief Reserved */
+#define RT_MII_AN_START    0x0200  /**< \brief Start auto-negotiation */
+#define RT_MII_DUPLEX      0x0100  /**< \brief 1 for full 0 for half. Ignored if AN enabled. */
+/** @} */
+
+/** \defgroup bba_miisb MII Status Bits
+    \brief    BBA media independent interface status register fields
+    @{
+*/
+#define RT_MII_LINK         0x0004  /**< \brief Link is present */
+#define RT_MII_AN_CAPABLE   0x0008  /**< \brief Can do auto negotiation */
+#define RT_MII_AN_COMPLETE  0x0020  /**< \brief Auto-negotiation complete */
+#define RT_MII_10_HALF      0x0800  /**< \brief Can do 10Mbit half duplex */
+#define RT_MII_10_FULL      0x1000  /**< \brief Can do 10Mbit full */
+#define RT_MII_100_HALF     0x2000  /**< \brief Can do 100Mbit half */
+#define RT_MII_100_FULL     0x4000  /**< \brief Can do 100Mbit full */
+/** @} */
+
+/** \defgroup bba_cbits Command Bits
+    \brief    BBA command register fields
+
+    OR appropriate bit values together and write into the RT_CHIPCMD register to
+    execute the command.
+
+    @{
+*/
+#define RT_CMD_RESET        0x10 /**< \brief Reset the RTL8139C */
+#define RT_CMD_RX_ENABLE    0x08 /**< \brief Enable Rx */
+#define RT_CMD_TX_ENABLE    0x04 /**< \brief Enable Tx */
+#define RT_CMD_RX_BUF_EMPTY 0x01 /**< \brief Empty the Rx buffer */
+/** @} */
+
+/** \defgroup bba_ibits Interrupt Status Bits
+    \brief    BBA interrupt status fields
+    @{
+*/
+#define RT_INT_PCIERR           0x8000  /**< \brief PCI Bus error */
+#define RT_INT_TIMEOUT          0x4000  /**< \brief Set when TCTR reaches TimerInt value */
+#define RT_INT_RXFIFO_OVERFLOW  0x0040  /**< \brief Rx FIFO overflow */
+#define RT_INT_RXFIFO_UNDERRUN  0x0020  /**< \brief Packet underrun / link change */
+#define RT_INT_LINK_CHANGE      0x0020  /**< \brief Packet underrun / link change */
+#define RT_INT_RXBUF_OVERFLOW   0x0010  /**< \brief Rx BUFFER overflow */
+#define RT_INT_TX_ERR           0x0008  /**< \brief Tx error */
+#define RT_INT_TX_OK            0x0004  /**< \brief Tx OK */
+#define RT_INT_RX_ERR           0x0002  /**< \brief Rx error */
+#define RT_INT_RX_OK            0x0001  /**< \brief Rx OK */
+
+/** \brief Composite RX bits we check for while doing an RX interrupt. */
 #define RT_INT_RX_ACK (RT_INT_RXFIFO_OVERFLOW | RT_INT_RXBUF_OVERFLOW | RT_INT_RX_OK)
+/** @} */
 
-/* RTL8139C transmit status bits */
-#define RT_TX_CARRIER_LOST     0x80000000 /* Carrier sense lost */
-#define RT_TX_ABORTED          0x40000000 /* Transmission aborted */
-#define RT_TX_OUT_OF_WINDOW    0x20000000 /* Out of window collision */
-#define RT_TX_STATUS_OK        0x00008000 /* Status ok: a good packet was transmitted */
-#define RT_TX_UNDERRUN         0x00004000 /* Transmit FIFO underrun */
-#define RT_TX_HOST_OWNS        0x00002000 /* Set to 1 when DMA operation is completed */
-#define RT_TX_SIZE_MASK        0x00001fff /* Descriptor size mask */
+/** \defgroup bba_tbits RTL8139C Transmit Status Bits
+    \brief    BBA transmit status register fields
+    @{
+*/
+#define RT_TX_CARRIER_LOST  0x80000000  /**< \brief Carrier sense lost */
+#define RT_TX_ABORTED       0x40000000  /**< \brief Transmission aborted */
+#define RT_TX_OUT_OF_WINDOW 0x20000000  /**< \brief Out of window collision */
+#define RT_TX_STATUS_OK     0x00008000  /**< \brief Status ok: a good packet was transmitted */
+#define RT_TX_UNDERRUN      0x00004000  /**< \brief Transmit FIFO underrun */
+#define RT_TX_HOST_OWNS     0x00002000  /**< \brief Set to 1 when DMA operation is completed */
+#define RT_TX_SIZE_MASK     0x00001fff  /**< \brief Descriptor size mask */
+/** @} */
 
-/* RTL8139C receive status bits */
-#define RT_RX_MULTICAST        0x00008000 /* Multicast packet */
-#define RT_RX_PAM              0x00004000 /* Physical address matched */
-#define RT_RX_BROADCAST        0x00002000 /* Broadcast address matched */
-#define RT_RX_BAD_SYMBOL       0x00000020 /* Invalid symbol in 100TX packet */
-#define RT_RX_RUNT             0x00000010 /* Packet size is <64 bytes */
-#define RT_RX_TOO_LONG         0x00000008 /* Packet size is >4K bytes */
-#define RT_RX_CRC_ERR          0x00000004 /* CRC error */
-#define RT_RX_FRAME_ALIGN      0x00000002 /* Frame alignment error */
-#define RT_RX_STATUS_OK        0x00000001 /* Status ok: a good packet was received */
+/** \defgroup bba_rbits Receive Status Bits
+    \brief    BBA receive status register fields
+    @{
+*/
+#define RT_RX_MULTICAST     0x8000  /**< \brief Multicast packet */
+#define RT_RX_PAM           0x4000  /**< \brief Physical address matched */
+#define RT_RX_BROADCAST     0x2000  /**< \brief Broadcast address matched */
+#define RT_RX_BAD_SYMBOL    0x0020  /**< \brief Invalid symbol in 100TX packet */
+#define RT_RX_RUNT          0x0010  /**< \brief Packet size is <64 bytes */
+#define RT_RX_TOO_LONG      0x0008  /**< \brief Packet size is >4K bytes */
+#define RT_RX_CRC_ERR       0x0004  /**< \brief CRC error */
+#define RT_RX_FRAME_ALIGN   0x0002  /**< \brief Frame alignment error */
+#define RT_RX_STATUS_OK     0x0001  /**< \brief Status ok: a good packet was received */
+/** @} */
+
+/** \defgroup bba_configrx RTL8139C RX Config Register (RT_RXCONFIG) bits
+
+    From RTL8139C(L) datasheet v1.4.
+
+    @{
+*/
+#define RT_ERTH(n)         ((n) <<24)  /**< \brief Early RX Threshold multiplier n/16 or 0 for none */
+
+#define RT_RXC_MulERINT    0x00020000  /**< \brief 0 for Early Receive Interrupt only on familiar protocols 1 for any */
+#define RT_RXC_RER8        0x00010000  /**< \brief 1 sets the acceptance of runt error packets */
+#define RT_RXC_RXFTH(n)    ((n) <<13)  /**< \brief 2^(4+n) bytes from 0-6 (16b - 1Kb) or 7 for none */
+#define RT_RXC_RBLEN(n)    ((n) <<11)  /**< \brief Set Rx ring buffer len to 16b + 2^(3+n) kb. */
+#define RT_RXC_MXDMA(n)    ((n) << 8)  /**< \brief 2^(4+n) bytes from 0-6 (16b - 1Kb) or 7 for unlimited */
+
+#define RT_RXC_WRAP        0x00000080  /**< \brief 0 to use wrapping mode or 1 to not (Ignored for 64Kb buffer length) */
+#define RT_RXC_9356SEL     0x00000040  /**< \brief 0 if EEPROM is 9346, 1 if 9356. RO */
+#define RT_RXC_AER         0x00000020  /**< \brief Accept Error Packets */
+#define RT_RXC_AR          0x00000010  /**< \brief Accept Runt (8-64 byte) Packets */
+#define RT_RXC_AB          0x00000008  /**< \brief Accept Broadcast Packets */
+#define RT_RXC_AM          0x00000004  /**< \brief Accept Multicast Packets */
+#define RT_RXC_APM         0x00000002  /**< \brief Accept Physical Match Packets */
+#define RT_RXC_AAP         0x00000001  /**< \brief Accept Physical Address Packets */
+/** @} */
+
+/** \defgroup bba_config1bits RTL8139C Config Register 1 (RT_CONFIG1) Bits
+    \brief    BBA config register 1 fields
+
+    From RTL8139C(L) datasheet v1.4
+
+    @{
+*/
+#define RT_CONFIG1_LED1     0x80 /**< \brief XXX DC bba has no LED, maybe repurposed. */
+#define RT_CONFIG1_LED0     0x40 /**< \brief XXX DC bba has no LED, maybe repurposed. */
+#define RT_CONFIG1_DVRLOAD  0x20 /**< \brief Sets the Driver as loaded. */
+#define RT_CONFIG1_LWACT    0x10 /**< \brief LWAKE active mode. Default 0. */
+#define RT_CONFIG1_MEMMAP   0x08 /**< \brief Registers mapped to PCI mem space. Read Only */
+#define RT_CONFIG1_IOMAP    0x04 /**< \brief Registers mapped to PCI I/O space. Read Only */
+#define RT_CONFIG1_VPD      0x02 /**< \brief Enable Vital Product Data. */
+#define RT_CONFIG1_PMEn     0x01 /**< \brief Power Management Enable */
+/** @} */
+
+/** \defgroup bba_config4bits RTL8139C Config Register 4 (RT_CONFIG4) Bits
+    \brief    BBA config register 4 fields
+
+    From RTL8139C(L) datasheet v1.4. Only RT_CONFIG4_RxFIFIOAC is used.
+
+    @{
+*/
+#define RT_CONFIG4_RxFIFIOAC 0x80 /**< \brief Auto-clear the Rx FIFO overflow. */
+#define RT_CONFIG4_AnaOff    0x40 /**< \brief Turn off analog power. Default 0. */
+#define RT_CONFIG4_LongWF    0x20 /**< \brief Long Wake-up Frames. */
+#define RT_CONFIG4_LWPME     0x10 /**< \brief LWake vs PMEB. */
+#define RT_CONFIG4_RES08     0x08 /**< \brief Reserved. */
+#define RT_CONFIG4_LWPTN     0x04 /**< \brief LWAKE Pattern. */
+#define RT_CONFIG4_RES02     0x02 /**< \brief Reserved. */
+#define RT_CONFIG4_PBWake    0x01 /**< \brief Disable pre-Boot Wakeup. */
+/** @} */
+
+/** \defgroup bba_config5bits RTL8139C Config Register 5 (RT_CONFIG5) Bits
+    \brief    BBA config register 5 fields
+
+    From RTL8139C(L) datasheet v1.4. Only RT_CONFIG5_LDPS is used.
+
+    @{
+*/
+#define RT_CONFIG5_RES80    0x80 /**< \brief Reserved. */
+#define RT_CONFIG5_BWF      0x40 /**< \brief Enable Broadcast Wakeup Frame. Default 0. */
+#define RT_CONFIG5_MWF      0x20 /**< \brief Enable Multicast Wakeup Frame. Default 0. */
+#define RT_CONFIG5_UWF      0x10 /**< \brief Enable Unicast Wakeup Frame. Default 0. */
+#define RT_CONFIG5_FIFOAddr 0x08 /**< \brief Set FIFO address pointer. For testing only. */
+#define RT_CONFIG5_LDPS     0x04 /**< \brief Disable Link Down Power Saving mode. */
+#define RT_CONFIG5_LANW     0x02 /**< \brief Enable LANWake signal. */
+#define RT_CONFIG5_PME_STS  0x01 /**< \brief Allow PCI reset to set PME_Status bit. */
+/** @} */
+
+/** @} */
+
+/** @} */
 
 /* Convienence macros */
 #define REGL(a) (volatile unsigned long *)(a)

--- a/target-src/dcload/rtl8139.h
+++ b/target-src/dcload/rtl8139.h
@@ -273,7 +273,7 @@ typedef struct {
 	unsigned char  mac[6];                /* Mac address */
 } rtl_status_t;
 
-int rtl_bb_detect(void);
+int gaps_detect(void);
 int rtl_bb_init(void);
 void rtl_bb_start(void);
 void rtl_bb_stop(void);

--- a/target-src/dcload/rtl8139.h
+++ b/target-src/dcload/rtl8139.h
@@ -269,7 +269,7 @@ typedef struct {
 } rtl_status_t;
 
 int gaps_detect(void);
-int rtl_bb_init(void);
+int gaps_init(void);
 void rtl_bb_start(void);
 void rtl_bb_stop(void);
 int rtl_bb_tx(unsigned char * pkt, int len);

--- a/target-src/dcload/rtl8139.h
+++ b/target-src/dcload/rtl8139.h
@@ -268,11 +268,4 @@ typedef struct {
 	unsigned char  mac[6];                /* Mac address */
 } rtl_status_t;
 
-int gaps_detect(void);
-int gaps_init(void);
-void rtl_bb_start(void);
-void rtl_bb_stop(void);
-int rtl_bb_tx(unsigned char * pkt, int len);
-void rtl_bb_loop(int is_main_loop);
-
 #endif


### PR DESCRIPTION
The intent with these changes is to try to harmonize the style and structure of the dcload-ip BBA driver with KOS' in order to help support improvements in either being moved to the other, additionally to help allow using the dcload driver as a base of testing by cleaning it up some.

Needs substantial review and testing to ensure no accidental regressions. There's still also further updates to be made for pieces like link change. Figured I'd put it up early though for review and commentary.